### PR TITLE
Add PointCloud to Video Routine

### DIFF
--- a/LICENSE-3rdparty
+++ b/LICENSE-3rdparty
@@ -4,62 +4,68 @@ This project includes the following third-party dependencies. Each is used unmod
 
 ---------------------------------------------------------------
 
-1. NumPy
+1. Matplotlib
+- License: Python Software Foundation License
+- Source: https://pypi.org/project/matplotlib/
+
+---------------------------------------------------------------
+
+2. NumPy
 - License: BSD 3-Clause License
 - Source: https://pypi.org/project/numpy/
 
 ---------------------------------------------------------------
 
-2. OpenCV (opencv-python-headless)
+3. OpenCV (opencv-python-headless)
 - License: Apache License 2.0
 - Source: https://pypi.org/project/opencv-python-headless/
 
 ---------------------------------------------------------------
 
-3. PyYAML
+4. PyYAML
 - License: MIT License
 - Source: https://pypi.org/project/PyYAML/
 
 ---------------------------------------------------------------
 
-4. pypcd4
+5. pypcd4
 - License: BSD 3-Clause License
 - Source: https://pypi.org/project/pypcd4/
 
 ---------------------------------------------------------------
 
-5. PySide6
+6. PySide6
 - License: GNU Lesser General Public License v3.0 (LGPL-3.0)
 - Source: https://pypi.org/project/PySide6/
 - Note: PySide6 is used as a dynamic dependency and has not been modified.
 
 ---------------------------------------------------------------
 
-6. rclpy
+7. rclpy
 - License: Apache License 2.0
 - Source: https://github.com/ros2/rclpy
 
 ---------------------------------------------------------------
 
-7. rosbag2_py
+8. rosbag2_py
 - License: Apache License 2.0
 - Source: https://github.com/ros2/rosbag2
 
 ---------------------------------------------------------------
 
-8. ros2cli
+9. ros2cli
 - License: Apache License 2.0
 - Source: https://github.com/ros2/ros2cli
 
 ---------------------------------------------------------------
 
-9. rosidl-runtime-py
+10. rosidl-runtime-py
 - License: Apache License 2.0
 - Source: https://github.com/ros2/rosidl_python
 
 ---------------------------------------------------------------
 
-10. tqdm
+11. tqdm
 - License: Apache License 2.0
 - Source: https://pypi.org/project/tqdm/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ keywords = ["ros2", "rosbag", "robotics", "perception", "ros2-export"]
 dynamic = ["version"]
 
 dependencies = [
+    "matplotlib==3.10.8",
     "numpy==1.26.4",
     "opencv-python-headless==4.11.0.86",
     "pypcd4==1.3.0",

--- a/ros2_unbag/core/exporter.py
+++ b/ros2_unbag/core/exporter.py
@@ -148,6 +148,7 @@ class Exporter:
                 "mode": mode,
                 "sequential": (mode == ExportMode.SINGLE_FILE),
                 "topic_base": topic.strip("/").replace("/", "_"),
+                "routine_args": cfg.get("routine_args") or {},
                 "name_tmpl": name_tmpl,
                 "path_tmpl": path_tmpl,
                 "sub_tmpl":  sub_tmpl,
@@ -655,7 +656,8 @@ class Exporter:
                 # Use pre-fetched export handler
                 export_handler = self.topic_handlers[topic]
                 if export_handler:
-                    export_handler(msg, full_path, fmt, metadata, topic=topic)
+                    routine_args = self._topic_cache[topic]["routine_args"]
+                    export_handler(msg, full_path, fmt, metadata, topic=topic, routine_args=routine_args)
                     progress_queue.put(1)
 
             except Exception as e:

--- a/ros2_unbag/core/routines/base.py
+++ b/ros2_unbag/core/routines/base.py
@@ -75,11 +75,11 @@ class ExportRoutine:
         """
         storage = defaultdict(dict)  # Define a persistent storage for each topic
 
-        def wrapper(msg, path, fmt, metadata, topic=None, routine_args=None):
-            wrapper.persistent_storage = storage[topic] if topic else {}
+        def wrapper(msg, path, fmt, metadata, topic=None, routine_args=None, **kwargs):
+            wrapper.persistent_storage = storage[topic]
             canonical_fmt, _ = ExportRoutine._split_format(fmt)
-            kwargs = routine_args or {}
-            return func(msg, path, canonical_fmt, metadata, **kwargs)
+            merged = {**(routine_args or {}), **kwargs}
+            return func(msg, path, canonical_fmt, metadata, **merged)
 
         wrapper.persistent_storage = {}  # Initialize persistent storage
         self.func = wrapper

--- a/ros2_unbag/core/routines/base.py
+++ b/ros2_unbag/core/routines/base.py
@@ -23,6 +23,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
+import inspect
 from typing import Dict, Iterable, Optional, Tuple
 
 
@@ -74,13 +75,15 @@ class ExportRoutine:
         """
         storage = defaultdict(dict)  # Define a persistent storage for each topic
 
-        def wrapper(msg, path, fmt, metadata, topic=None):
+        def wrapper(msg, path, fmt, metadata, topic=None, routine_args=None):
             wrapper.persistent_storage = storage[topic] if topic else {}
             canonical_fmt, _ = ExportRoutine._split_format(fmt)
-            return func(msg, path, canonical_fmt, metadata)
+            kwargs = routine_args or {}
+            return func(msg, path, canonical_fmt, metadata, **kwargs)
 
         wrapper.persistent_storage = {}  # Initialize persistent storage
         self.func = wrapper
+        self._original_func = func  # Keep reference for signature introspection
         return wrapper
 
 
@@ -159,6 +162,78 @@ class ExportRoutine:
             return None
         routine, _, _ = resolved
         return routine.func
+
+    @classmethod
+    def get_args(cls, msg_type, fmt):
+        """
+        Return the extra keyword arguments (beyond the 4 fixed positional args) declared by the
+        registered routine for the given message type and format.
+
+        Returns a dict mapping parameter name to a (inspect.Parameter, doc_str) tuple,
+        mirroring the interface of Processor.get_args().
+
+        Args:
+            msg_type: Message type string.
+            fmt: Export format string.
+
+        Returns:
+            dict: Mapping of parameter name to (inspect.Parameter, description string).
+                  Empty dict if no routine is found or no extra args are declared.
+        """
+        resolved = cls.resolve(msg_type, fmt)
+        if not resolved:
+            return {}
+        routine, _, _ = resolved
+        if not hasattr(routine, "_original_func"):
+            return {}
+        func = routine._original_func
+        sig = inspect.signature(func)
+        doc = inspect.getdoc(func)
+        param_docs = cls._extract_param_docs(doc)
+        # Skip the 4 fixed positional args of every routine
+        _SKIP = {"msg", "path", "fmt", "metadata"}
+        return {
+            name: (param, param_docs.get(name, ""))
+            for name, param in sig.parameters.items()
+            if name not in _SKIP
+        }
+
+    @staticmethod
+    def _extract_param_docs(docstring):
+        """
+        Extract parameter descriptions from a Google-style docstring.
+
+        Args:
+            docstring: The full docstring of the routine function.
+
+        Returns:
+            dict: Mapping of parameter name to description string.
+        """
+        import re
+
+        if not docstring:
+            return {}
+
+        param_docs = {}
+        lines = docstring.splitlines()
+        in_args = False
+        for line in lines:
+            line = line.strip()
+            if line.startswith("Args:"):
+                in_args = True
+                continue
+            if in_args:
+                if re.match(r"^\w+\s*\(.*\):", line):  # param with type
+                    key = line.split(":", 1)[0].split("(")[0].strip()
+                    desc = line.split(":", 1)[1].strip()
+                    param_docs[key] = desc
+                elif re.match(r"^\w+\s*:", line):  # param without type
+                    key = line.split(":", 1)[0].strip()
+                    desc = line.split(":", 1)[1].strip()
+                    param_docs[key] = desc
+                elif line == "":
+                    break  # end of block
+        return param_docs
     
     @classmethod
     def get_mode(cls, msg_type, fmt):

--- a/ros2_unbag/core/routines/default.py
+++ b/ros2_unbag/core/routines/default.py
@@ -31,7 +31,14 @@ from ros2_unbag.core.utils.file_utils import get_time_from_msg
 
 
 @ExportRoutine.set_catch_all(["text/json", "text/yaml", "table/csv"], mode=ExportMode.MULTI_FILE)
-def export_generic_multi_file(msg, path: Path, fmt: str, metadata: ExportMetadata):
+def export_generic_multi_file(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    json_indent: int = None,
+    csv_delimiter: str = ",",
+):
     """
     Generic export handler supporting JSON, YAML, and CSV formats. 
     Serialize the message, determine file extension, and save to the given path.
@@ -41,14 +48,18 @@ def export_generic_multi_file(msg, path: Path, fmt: str, metadata: ExportMetadat
         path: Output file path (without extension).
         fmt: Export format string ("text/yaml", "text/json", "table/csv").
         metadata: Export metadata including message index and max index.
+        json_indent (int or None): Indentation level for JSON pretty-printing. None produces compact single-line output.
+        csv_delimiter (str): Column delimiter for CSV output (e.g. ",", ";", "\\t").
 
     Returns:
         None
     """
+    json_indent = int(json_indent) if json_indent is not None else None
+
     timestamp = get_time_from_msg(msg, return_datetime=True)
 
     if fmt == "text/json":
-        payload = _serialize_message_with_timestamp(msg, "json", timestamp)
+        payload = _serialize_message_with_timestamp(msg, "json", timestamp, json_indent=json_indent)
         file_ending = ".json"
     elif fmt == "text/yaml":
         payload = _serialize_message_with_timestamp(msg, "yaml", timestamp)
@@ -59,11 +70,18 @@ def export_generic_multi_file(msg, path: Path, fmt: str, metadata: ExportMetadat
 
     # Save the serialized message to a file
     with open(path.with_suffix(file_ending), "w") as f:
-        _write_line(f, payload, fmt, True, True)
+        _write_line(f, payload, fmt, True, True, csv_delimiter=csv_delimiter)
 
 
 @ExportRoutine.set_catch_all(["text/json", "text/yaml", "table/csv"], mode=ExportMode.SINGLE_FILE)
-def export_generic_single_file(msg, path: Path, fmt: str, metadata: ExportMetadata):
+def export_generic_single_file(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    json_indent: int = None,
+    csv_delimiter: str = ",",
+):
     """
     Generic export handler supporting JSON, YAML, and CSV formats.
     Serialize the message, determine file extension, and append to the given path with file locking (precaution).
@@ -73,14 +91,18 @@ def export_generic_single_file(msg, path: Path, fmt: str, metadata: ExportMetada
         path: Output file path (without extension).
         fmt: Export format string ("text/yaml", "text/json", "table/csv").
         metadata: Export metadata including message index and max index.
+        json_indent (int or None): Indentation level for JSON pretty-printing. None produces compact single-line output.
+        csv_delimiter (str): Column delimiter for CSV output (e.g. ",", ";", "\\t").
 
     Returns:
         None
     """
+    json_indent = int(json_indent) if json_indent is not None else None
+
     timestamp = get_time_from_msg(msg, return_datetime=True)
 
     if fmt == "text/json":
-        payload = _serialize_message_with_timestamp(msg, "json", timestamp)
+        payload = _serialize_message_with_timestamp(msg, "json", timestamp, json_indent=json_indent)
         file_ending = ".json"
     elif fmt == "text/yaml":
         payload = _serialize_message_with_timestamp(msg, "yaml", timestamp)
@@ -100,10 +122,10 @@ def export_generic_single_file(msg, path: Path, fmt: str, metadata: ExportMetada
             f.seek(0)
             f.truncate()
         # Write payload line to the file
-        _write_line(f, payload, fmt, is_first, is_last)
+        _write_line(f, payload, fmt, is_first, is_last, csv_delimiter=csv_delimiter)
 
 
-def _serialize_message_with_timestamp(msg, fmt, timestamp):
+def _serialize_message_with_timestamp(msg, fmt, timestamp, json_indent=None):
     """
     Serialize a ROS message to the specified format.
 
@@ -111,13 +133,14 @@ def _serialize_message_with_timestamp(msg, fmt, timestamp):
         msg: ROS message instance to serialize.
         fmt: Export format string ("yaml", "json", "csv").
         timestamp: Timestamp to include in the serialized output.
+        json_indent (int or None): Indentation for JSON output.
 
     Returns:
         str: Serialized message as a string.
     """
     if fmt == "json":
         message_dict = message_to_ordereddict(msg)
-        serialized_line = json.dumps(message_dict, default=str)
+        serialized_line = json.dumps(message_dict, default=str, indent=json_indent)
         serialized_line_with_timestamp = f'"{timestamp.isoformat()}": {serialized_line}'
         return serialized_line_with_timestamp
     elif fmt == "yaml":
@@ -132,7 +155,7 @@ def _serialize_message_with_timestamp(msg, fmt, timestamp):
         return [header, values]
 
 
-def _write_line(file, line, filetype, is_first, is_last):
+def _write_line(file, line, filetype, is_first, is_last, csv_delimiter=","):
     """
     Write a serialized message line to the file.
     For JSON/YAML, write the string; for CSV, ensure header and write the row.
@@ -143,6 +166,7 @@ def _write_line(file, line, filetype, is_first, is_last):
         filetype: Export format string.
         is_first: Boolean indicating if this is the first message for the file.
         is_last: Boolean indicating if this is the last message for the file.
+        csv_delimiter (str): Column delimiter for CSV output.
 
     Returns:
         None
@@ -166,27 +190,28 @@ def _write_line(file, line, filetype, is_first, is_last):
     # Writing for csv - include header only for the first line
     if "table/csv" in filetype:
         if is_first:
-            _add_csv_header(file, line[0])
-        writer = csv.writer(file)
+            _add_csv_header(file, line[0], csv_delimiter)
+        writer = csv.writer(file, delimiter=csv_delimiter)
         writer.writerow(line[1])   
 
     file.flush()
 
 
-def _add_csv_header(file, header):
+def _add_csv_header(file, header, csv_delimiter=","):
     """
     Ensure the CSV file starts with the correct header.
 
     Args:
         file: File object to write to.
         header: List of column names for the CSV header.
+        csv_delimiter (str): Column delimiter for CSV output.
 
     Returns:
         None
     """
     file.seek(0)
     file.truncate()
-    writer = csv.writer(file)
+    writer = csv.writer(file, delimiter=csv_delimiter)
     writer.writerow(header)
 
 

--- a/ros2_unbag/core/routines/image.py
+++ b/ros2_unbag/core/routines/image.py
@@ -23,44 +23,84 @@
 import cv2
 import numpy as np
 from pathlib import Path
+from typing import Optional
 
 from ros2_unbag.core.routines.base import ExportRoutine, ExportMode, ExportMetadata
 from ros2_unbag.core.utils.image_utils import convert_image
 
 
 @ExportRoutine("sensor_msgs/msg/CompressedImage", ["image/png", "image/jpeg"], mode=ExportMode.MULTI_FILE)
-def export_compressed_image(msg, path: Path, fmt: str, metadata: ExportMetadata):
+def export_compressed_image(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    jpeg_quality: int = 95,
+    png_compression: int = 3,
+    resize_width: Optional[int] = None,
+    resize_height: Optional[int] = None,
+):
     """
     Export a CompressedImage ROS message to PNG or JPEG.
-    If the message is already in the desired format, write raw data; otherwise decode and re-encode with OpenCV.
+    If the message is already in the desired format and no resize/quality params are set,
+    write raw data directly; otherwise decode and re-encode with OpenCV.
 
     Args:
         msg: CompressedImage ROS message instance.
         path: Output file path (without extension).
         fmt: Export format string ("image/png" or "image/jpeg").
         metadata: Export metadata including message index and max index.
+        jpeg_quality (int): JPEG compression quality (1–100). Only used when exporting as JPEG.
+        png_compression (int): PNG compression level (0–9, where 0 = no compression, 9 = maximum). Only used when exporting as PNG.
+        resize_width (int or None): Target width in pixels. Height is computed to preserve aspect ratio when only one dimension is given.
+        resize_height (int or None): Target height in pixels. Width is computed to preserve aspect ratio when only one dimension is given.
 
     Returns:
         None
     """
+    jpeg_quality = int(jpeg_quality)
+    png_compression = int(png_compression)
+    resize_width = int(resize_width) if resize_width is not None else None
+    resize_height = int(resize_height) if resize_height is not None else None
+
     desired_fmt = "jpeg" if fmt == "image/jpeg" else "png"
     msg_fmt = msg.format.lower()
+    ext = ".jpg" if desired_fmt == "jpeg" else ".png"
 
-    if desired_fmt in msg_fmt:
-        # If message is already in the desired format, write directly
-        ext = ".jpg" if desired_fmt == "jpeg" else ".png"
+    needs_reencode = (
+        desired_fmt not in msg_fmt
+        or resize_width is not None
+        or resize_height is not None
+        or (desired_fmt == "jpeg" and jpeg_quality != 95)
+        or (desired_fmt == "png" and png_compression != 3)
+    )
+
+    if not needs_reencode:
         with open(path.with_suffix(ext), "wb") as f:
             f.write(msg.data)
+        return
+
+    np_arr = np.frombuffer(msg.data, np.uint8)
+    img = cv2.imdecode(np_arr, cv2.IMREAD_UNCHANGED)
+    img = _apply_resize(img, resize_width, resize_height)
+    if desired_fmt == "jpeg":
+        encode_params = [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality]
     else:
-        # Decode and re-encode to desired format
-        np_arr = np.frombuffer(msg.data, np.uint8)
-        img = cv2.imdecode(np_arr, cv2.IMREAD_UNCHANGED)
-        ext = ".jpg" if desired_fmt == "jpeg" else ".png"
-        cv2.imwrite(path.with_suffix(ext), img)
+        encode_params = [cv2.IMWRITE_PNG_COMPRESSION, png_compression]
+    cv2.imwrite(str(path.with_suffix(ext)), img, encode_params)
 
 
 @ExportRoutine("sensor_msgs/msg/Image", ["image/png", "image/jpeg"], mode=ExportMode.MULTI_FILE)
-def export_raw_image(msg, path: Path, fmt: str, metadata: ExportMetadata):
+def export_raw_image(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    jpeg_quality: int = 95,
+    png_compression: int = 3,
+    resize_width: Optional[int] = None,
+    resize_height: Optional[int] = None,
+):
     """
     Export a raw Image ROS message to PNG or JPEG using OpenCV.
 
@@ -69,6 +109,10 @@ def export_raw_image(msg, path: Path, fmt: str, metadata: ExportMetadata):
         path: Output file path (without extension).
         fmt: Export format string ("image/png" or "image/jpeg").
         metadata: Export metadata including message index and max index.
+        jpeg_quality (int): JPEG compression quality (1–100). Only used when exporting as JPEG.
+        png_compression (int): PNG compression level (0–9, where 0 = no compression, 9 = maximum). Only used when exporting as PNG.
+        resize_width (int or None): Target width in pixels. Height is computed to preserve aspect ratio when only one dimension is given.
+        resize_height (int or None): Target height in pixels. Width is computed to preserve aspect ratio when only one dimension is given.
 
     Returns:
         None
@@ -76,12 +120,33 @@ def export_raw_image(msg, path: Path, fmt: str, metadata: ExportMetadata):
     Raises:
         ValueError: If encoding or export format is unsupported.
     """
+    jpeg_quality = int(jpeg_quality)
+    png_compression = int(png_compression)
+    resize_width = int(resize_width) if resize_width is not None else None
+    resize_height = int(resize_height) if resize_height is not None else None
 
     raw = np.frombuffer(msg.data, dtype=np.uint8)
     img = convert_image(raw, msg.encoding, msg.width, msg.height)
+    img = _apply_resize(img, resize_width, resize_height)
 
-    ext = { "image/png": ".png", "image/jpeg": ".jpg" }.get(fmt)
+    ext = {"image/png": ".png", "image/jpeg": ".jpg"}.get(fmt)
     if not ext:
         raise ValueError(f"Unsupported export format: {fmt}")
 
-    cv2.imwrite(path.with_suffix(ext), img)
+    if fmt == "image/jpeg":
+        encode_params = [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality]
+    else:
+        encode_params = [cv2.IMWRITE_PNG_COMPRESSION, png_compression]
+    cv2.imwrite(str(path.with_suffix(ext)), img, encode_params)
+
+
+def _apply_resize(img, width: Optional[int], height: Optional[int]):
+    """Resize img to (width, height), preserving aspect ratio when only one dimension is given."""
+    if width is None and height is None:
+        return img
+    h, w = img.shape[:2]
+    if width is None:
+        width = int(round(w * height / h))
+    elif height is None:
+        height = int(round(h * width / w))
+    return cv2.resize(img, (int(width), int(height)))

--- a/ros2_unbag/core/routines/pointcloud.py
+++ b/ros2_unbag/core/routines/pointcloud.py
@@ -51,7 +51,14 @@ def export_pointcloud_pkl(msg, path: Path, fmt: str, metadata: ExportMetadata):
 
 
 @ExportRoutine("sensor_msgs/msg/PointCloud2", ["pointcloud/xyz"], mode=ExportMode.MULTI_FILE)
-def export_pointcloud_xyz(msg, path: Path, fmt: str, metadata: ExportMetadata):
+def export_pointcloud_xyz(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    extra_fields: str = "",
+    filter_nan: bool = True,
+):
     """
     Export PointCloud2 message as an XYZ text file by unpacking x, y, z floats from each point and writing lines.
 
@@ -60,10 +67,16 @@ def export_pointcloud_xyz(msg, path: Path, fmt: str, metadata: ExportMetadata):
         path: Output file path (without extension).
         fmt: Export format string (default "pointcloud/xyz").
         metadata: Export metadata including message index and max index.
+        extra_fields (str): Space-separated list of additional field names to append after X Y Z on each line
+            (e.g. "intensity ring"). Each field must exist in the message.
+        filter_nan (bool): When True, points containing NaN in x, y, or z are skipped.
 
     Returns:
         None
     """
+    if isinstance(filter_nan, str):
+        filter_nan = filter_nan.lower() not in ("false", "0", "no")
+
     # Validate required fields
     field_by_name = {f.name: f for f in msg.fields}
     for name in ("x", "y", "z"):
@@ -74,6 +87,14 @@ def export_pointcloud_xyz(msg, path: Path, fmt: str, metadata: ExportMetadata):
     for name in ("x", "y", "z"):
         if field_by_name[name].datatype != PointField.FLOAT32:
             raise ValueError(f"Field '{name}' must be FLOAT32")
+
+    # Resolve extra field names
+    extra_field_names = [f for f in extra_fields.split() if f] if extra_fields else []
+    extra_field_infos = []
+    for name in extra_field_names:
+        if name not in field_by_name:
+            raise ValueError(f"PointCloud2 missing extra field '{name}'")
+        extra_field_infos.append(field_by_name[name])
 
     offx, offy, offz = field_by_name["x"].offset, field_by_name["y"].offset, field_by_name["z"].offset
     endian = ">" if msg.is_bigendian else "<"
@@ -86,9 +107,15 @@ def export_pointcloud_xyz(msg, path: Path, fmt: str, metadata: ExportMetadata):
             x = struct.unpack_from(endian + "f", data, i + offx)[0]
             y = struct.unpack_from(endian + "f", data, i + offy)[0]
             z = struct.unpack_from(endian + "f", data, i + offz)[0]
-            if not msg.is_dense and (math.isnan(x) or math.isnan(y) or math.isnan(z)):
+            if filter_nan and (math.isnan(x) or math.isnan(y) or math.isnan(z)):
                 continue
-            f.write(f"{x} {y} {z}\n")
+            if extra_field_infos:
+                extra_vals = " ".join(
+                    str(_unpack_field(endian, data, i, fi)) for fi in extra_field_infos
+                )
+                f.write(f"{x} {y} {z} {extra_vals}\n")
+            else:
+                f.write(f"{x} {y} {z}\n")
 
 
 @ExportRoutine("sensor_msgs/msg/PointCloud2", ["pointcloud/pcd", "pointcloud/pcd_compressed", "pointcloud/pcd_ascii"], mode=ExportMode.MULTI_FILE)
@@ -118,3 +145,23 @@ def export_pointcloud_pcd(msg, path: Path, fmt: str, metadata: ExportMetadata):
         pc.save(path.with_suffix(".pcd"), encoding=Encoding.BINARY_COMPRESSED)
     elif fmt == "pointcloud/pcd_ascii":
         pc.save(path.with_suffix(".pcd"), encoding=Encoding.ASCII)
+
+
+_FIELD_STRUCT = {
+    PointField.INT8:    "b",
+    PointField.UINT8:   "B",
+    PointField.INT16:   "h",
+    PointField.UINT16:  "H",
+    PointField.INT32:   "i",
+    PointField.UINT32:  "I",
+    PointField.FLOAT32: "f",
+    PointField.FLOAT64: "d",
+}
+
+
+def _unpack_field(endian: str, data, point_offset: int, field):
+    """Unpack a single scalar value from a PointCloud2 data buffer for the given field."""
+    fmt_char = _FIELD_STRUCT.get(field.datatype)
+    if fmt_char is None:
+        raise ValueError(f"Unsupported PointField datatype {field.datatype} for field '{field.name}'")
+    return struct.unpack_from(endian + fmt_char, data, point_offset + field.offset)[0]

--- a/ros2_unbag/core/routines/pointcloud_video.py
+++ b/ros2_unbag/core/routines/pointcloud_video.py
@@ -1,0 +1,135 @@
+# MIT License
+
+# Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+PointCloud Video Export Routine.
+
+Renders each PointCloud2 frame into a colourised image and encodes all frames
+into a single MP4 or AVI video file.  Colour is driven by any scalar field
+present in the cloud (e.g. z-height, intensity, ring id) and a matplotlib
+colormap.  Multiple orthographic projections (top-down, front, side) and a
+full 3-D matplotlib scatter view are supported.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from ros2_unbag.core.routines.base import ExportRoutine, ExportMode, ExportMetadata
+from ros2_unbag.core.utils.file_utils import get_time_from_msg
+from ros2_unbag.core.utils.video_utils import write_video_frame, finalize_video
+from ros2_unbag.core.utils.pointcloud_video_utils import render_frame
+
+
+@ExportRoutine(
+    "sensor_msgs/msg/PointCloud2",
+    ["pointcloud/video_mp4", "pointcloud/video_avi"],
+    mode=ExportMode.SINGLE_FILE,
+)
+def export_pointcloud_video(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    color_field: str = "intensity",
+    colormap: str = "viridis",
+    width: int = 1280,
+    height: int = 720,
+    point_size: int = 2,
+    range_min: Optional[float] = None,
+    range_max: Optional[float] = None,
+    projection: str = "topdown",
+    x_range: float = 50.0,
+    y_range: float = 50.0,
+    view_azimuth: float = 45.0,
+    view_elevation: float = 30.0,
+    bg_color: str = "black",
+):
+    """
+    Export a sequence of PointCloud2 messages as a colourised video.
+
+    Each message is rendered into a BGR image frame according to the chosen
+    projection and colormap, then encoded into a video file via OpenCV.
+
+    Args:
+        msg: PointCloud2 ROS message instance.
+        path (Path): Output file path (without extension).
+        fmt (str): Export format string ("pointcloud/video_mp4" or "pointcloud/video_avi").
+        metadata (ExportMetadata): Export metadata including message index and max index.
+        color_field (str): Point field used to drive the colormap (e.g. "z", "intensity").
+        colormap (str): Matplotlib colormap name (e.g. "jet", "viridis", "turbo").
+        width (int): Output frame width in pixels.
+        height (int): Output frame height in pixels.
+        point_size (int): Rendered point radius in pixels.
+        range_min (float or None): Lower bound for colormap normalisation. Auto-detected per frame when None.
+        range_max (float or None): Upper bound for colormap normalisation. Auto-detected per frame when None.
+        projection (str): View mode: "topdown", "front", "side", or "matplotlib3d".
+        x_range (float): Half-width of the visible scene in metres (orthographic modes).
+        y_range (float): Half-height of the visible scene in metres (orthographic modes).
+        view_azimuth (float): Camera azimuth angle in degrees (matplotlib3d only).
+        view_elevation (float): Camera elevation angle in degrees (matplotlib3d only).
+        bg_color (str): Background colour: "black" or "white".
+
+    Returns:
+        None
+    """
+    ps = export_pointcloud_video.persistent_storage
+    ts_ns = get_time_from_msg(msg, return_datetime=False)
+
+    # Convert string values coming from CLI / JSON config to the correct types
+    width = int(width)
+    height = int(height)
+    point_size = int(point_size)
+    x_range = float(x_range)
+    y_range = float(y_range)
+    view_azimuth = float(view_azimuth)
+    view_elevation = float(view_elevation)
+    range_min = float(range_min) if range_min is not None else None
+    range_max = float(range_max) if range_max is not None else None
+
+    # Map format key to the video format expected by video_utils
+    _FMT_MAP = {
+        "pointcloud/video_mp4": "video/mp4",
+        "pointcloud/video_avi": "video/avi",
+    }
+    video_fmt = _FMT_MAP.get(fmt, "video/mp4")
+
+    img = render_frame(
+        msg,
+        color_field=color_field,
+        colormap=colormap,
+        width=width,
+        height=height,
+        point_size=point_size,
+        range_min=range_min,
+        range_max=range_max,
+        projection=projection,
+        x_range=x_range,
+        y_range=y_range,
+        view_azimuth=view_azimuth,
+        view_elevation=view_elevation,
+        bg_color=bg_color,
+    )
+
+    write_video_frame(ps, img, ts_ns, path, video_fmt)
+
+    if metadata.index == metadata.max_index:
+        finalize_video(ps, path, video_fmt)

--- a/ros2_unbag/core/routines/pointcloud_video.py
+++ b/ros2_unbag/core/routines/pointcloud_video.py
@@ -59,8 +59,11 @@ def export_pointcloud_video(
     projection: str = "topdown",
     x_range: float = 50.0,
     y_range: float = 50.0,
+    z_range: float = 10.0,
     view_azimuth: float = 45.0,
     view_elevation: float = 30.0,
+    view_roll: float = 0.0,
+    zoom: float = 1.0,
     bg_color: str = "black",
 ):
     """
@@ -79,13 +82,16 @@ def export_pointcloud_video(
         width (int): Output frame width in pixels.
         height (int): Output frame height in pixels.
         point_size (int): Rendered point radius in pixels.
-        range_min (float or None): Lower bound for colormap normalisation. Auto-detected per frame when None.
-        range_max (float or None): Upper bound for colormap normalisation. Auto-detected per frame when None.
+        range_min (float or None): Lower clip bound for color_field values. Values below this receive the colormap's lowest colour. Auto-detected per frame when None.
+        range_max (float or None): Upper clip bound for color_field values. Values above this receive the colormap's highest colour. Auto-detected per frame when None.
         projection (str): View mode: "topdown", "front", "side", or "matplotlib3d".
-        x_range (float): Half-width of the visible scene in metres (orthographic modes).
-        y_range (float): Half-height of the visible scene in metres (orthographic modes).
+        x_range (float): Half-width of the visible scene in metres (x-axis).
+        y_range (float): Half-height of the visible scene in metres (y-axis).
+        z_range (float): Half-depth of the visible scene in metres (z-axis, matplotlib3d only).
         view_azimuth (float): Camera azimuth angle in degrees (matplotlib3d only).
         view_elevation (float): Camera elevation angle in degrees (matplotlib3d only).
+        view_roll (float): Camera roll angle in degrees (matplotlib3d only).
+        zoom (float): Zoom factor; values > 1 zoom in, < 1 zoom out (matplotlib3d only).
         bg_color (str): Background colour: "black" or "white".
 
     Returns:
@@ -100,8 +106,11 @@ def export_pointcloud_video(
     point_size = int(point_size)
     x_range = float(x_range)
     y_range = float(y_range)
+    z_range = float(z_range)
     view_azimuth = float(view_azimuth)
     view_elevation = float(view_elevation)
+    view_roll = float(view_roll)
+    zoom = float(zoom)
     range_min = float(range_min) if range_min is not None else None
     range_max = float(range_max) if range_max is not None else None
 
@@ -124,8 +133,11 @@ def export_pointcloud_video(
         projection=projection,
         x_range=x_range,
         y_range=y_range,
+        z_range=z_range,
         view_azimuth=view_azimuth,
         view_elevation=view_elevation,
+        view_roll=view_roll,
+        zoom=zoom,
         bg_color=bg_color,
     )
 

--- a/ros2_unbag/core/routines/pointcloud_video.py
+++ b/ros2_unbag/core/routines/pointcloud_video.py
@@ -26,8 +26,7 @@ PointCloud Video Export Routine.
 Renders each PointCloud2 frame into a colourised image and encodes all frames
 into a single MP4 or AVI video file.  Colour is driven by any scalar field
 present in the cloud (e.g. z-height, intensity, ring id) and a matplotlib
-colormap.  Multiple orthographic projections (top-down, front, side) and a
-full 3-D matplotlib scatter view are supported.
+colormap. 
 """
 
 from pathlib import Path
@@ -56,7 +55,6 @@ def export_pointcloud_video(
     point_size: int = 2,
     range_min: Optional[float] = None,
     range_max: Optional[float] = None,
-    projection: str = "topdown",
     x_range: float = 50.0,
     y_range: float = 50.0,
     z_range: float = 10.0,
@@ -70,7 +68,7 @@ def export_pointcloud_video(
     Export a sequence of PointCloud2 messages as a colourised video.
 
     Each message is rendered into a BGR image frame according to the chosen
-    projection and colormap, then encoded into a video file via OpenCV.
+    colormap, then encoded into a video file via OpenCV.
 
     Args:
         msg: PointCloud2 ROS message instance.
@@ -84,7 +82,6 @@ def export_pointcloud_video(
         point_size (int): Rendered point radius in pixels.
         range_min (float or None): Lower clip bound for color_field values. Values below this receive the colormap's lowest colour. Auto-detected per frame when None.
         range_max (float or None): Upper clip bound for color_field values. Values above this receive the colormap's highest colour. Auto-detected per frame when None.
-        projection (str): View mode: "topdown", "front", "side", or "matplotlib3d".
         x_range (float): Half-width of the visible scene in metres (x-axis).
         y_range (float): Half-height of the visible scene in metres (y-axis).
         z_range (float): Half-depth of the visible scene in metres (z-axis, matplotlib3d only).
@@ -130,7 +127,6 @@ def export_pointcloud_video(
         point_size=point_size,
         range_min=range_min,
         range_max=range_max,
-        projection=projection,
         x_range=x_range,
         y_range=y_range,
         z_range=z_range,

--- a/ros2_unbag/core/routines/video.py
+++ b/ros2_unbag/core/routines/video.py
@@ -23,6 +23,7 @@
 import cv2
 import numpy as np
 from pathlib import Path
+from typing import Optional
 
 from ros2_unbag.core.routines.base import ExportRoutine, ExportMode, ExportMetadata
 from ros2_unbag.core.utils.image_utils import convert_image
@@ -30,24 +31,43 @@ from ros2_unbag.core.utils.file_utils import get_time_from_msg
 from ros2_unbag.core.utils.video_utils import ensure_bgr, write_video_frame, finalize_video
 
 @ExportRoutine("sensor_msgs/msg/CompressedImage", ["video/mp4", "video/avi"], mode=ExportMode.SINGLE_FILE)
-def export_compressed_video(msg, path: Path, fmt: str, metadata: ExportMetadata):
+def export_compressed_video(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    target_fps: Optional[float] = None,
+    resize_width: Optional[int] = None,
+    resize_height: Optional[int] = None,
+):
     """
     Export a sequence of compressed image ROS messages to a video file using OpenCV.
 
     Args:
         msg: CompressedImage ROS message instance.
         path: Output file path (without extension).
-        fmt: Export format string ("video/mp4" or "video.avi").
+        fmt: Export format string ("video/mp4" or "video/avi").
         metadata: Export metadata including message index and max index.
+        target_fps (float or None): Override the auto-detected frame rate. When None, FPS is
+            estimated from the timestamp delta between the first two frames.
+        resize_width (int or None): Target width in pixels. Height is computed to preserve aspect ratio when only one dimension is given.
+        resize_height (int or None): Target height in pixels. Width is computed to preserve aspect ratio when only one dimension is given.
 
     Returns:
         None
     """
+    target_fps = float(target_fps) if target_fps is not None else None
+    resize_width = int(resize_width) if resize_width is not None else None
+    resize_height = int(resize_height) if resize_height is not None else None
+
     np_arr = np.frombuffer(msg.data, dtype=np.uint8)
     img = cv2.imdecode(np_arr, cv2.IMREAD_UNCHANGED)
     img = ensure_bgr(img)
+    img = _apply_resize(img, resize_width, resize_height)
 
     ps = export_compressed_video.persistent_storage
+    if target_fps is not None:
+        ps["target_fps"] = target_fps
     ts_ns = get_time_from_msg(msg, return_datetime=False)
 
     write_video_frame(ps, img, ts_ns, path, fmt)
@@ -57,27 +77,58 @@ def export_compressed_video(msg, path: Path, fmt: str, metadata: ExportMetadata)
 
 
 @ExportRoutine("sensor_msgs/msg/Image", ["video/mp4", "video/avi"], mode=ExportMode.SINGLE_FILE)
-def export_video(msg, path: Path, fmt: str, metadata: ExportMetadata):
+def export_video(
+    msg,
+    path: Path,
+    fmt: str,
+    metadata: ExportMetadata,
+    target_fps: Optional[float] = None,
+    resize_width: Optional[int] = None,
+    resize_height: Optional[int] = None,
+):
     """
     Export a sequence of raw Image ROS messages to a video file using OpenCV.
 
     Args:
         msg: Image ROS message instance.
         path: Output file path (without extension).
-        fmt: Export format string ("video/mp4" or "video.avi").
+        fmt: Export format string ("video/mp4" or "video/avi").
         metadata: Export metadata including message index and max index.
+        target_fps (float or None): Override the auto-detected frame rate. When None, FPS is
+            estimated from the timestamp delta between the first two frames.
+        resize_width (int or None): Target width in pixels. Height is computed to preserve aspect ratio when only one dimension is given.
+        resize_height (int or None): Target height in pixels. Width is computed to preserve aspect ratio when only one dimension is given.
 
     Returns:
         None
     """
+    target_fps = float(target_fps) if target_fps is not None else None
+    resize_width = int(resize_width) if resize_width is not None else None
+    resize_height = int(resize_height) if resize_height is not None else None
+
     raw = np.frombuffer(msg.data, dtype=np.uint8)
     img = convert_image(raw, msg.encoding, msg.width, msg.height)
     img = ensure_bgr(img)
+    img = _apply_resize(img, resize_width, resize_height)
 
     ps = export_video.persistent_storage
+    if target_fps is not None:
+        ps["target_fps"] = target_fps
     ts_ns = get_time_from_msg(msg, return_datetime=False)
 
     write_video_frame(ps, img, ts_ns, path, fmt)
 
     if metadata.index == metadata.max_index:
         finalize_video(ps, path, fmt)
+
+
+def _apply_resize(img, width: Optional[int], height: Optional[int]):
+    """Resize img to (width, height), preserving aspect ratio when only one dimension is given."""
+    if width is None and height is None:
+        return img
+    h, w = img.shape[:2]
+    if width is None:
+        width = int(round(w * height / h))
+    elif height is None:
+        height = int(round(h * width / w))
+    return cv2.resize(img, (int(width), int(height)))

--- a/ros2_unbag/core/utils/pointcloud_video_utils.py
+++ b/ros2_unbag/core/utils/pointcloud_video_utils.py
@@ -269,7 +269,7 @@ def _render_matplotlib3d(
     """
     # Use the Agg canvas explicitly so we never touch the global backend
     # registry (which would conflict with the interactive Qt canvas used by
-    # CameraPreviewDialog when the GUI is running).
+    # PointcloudPreviewDialog when the GUI is running).
     from matplotlib.backends.backend_agg import FigureCanvasAgg
     from matplotlib.figure import Figure as MplFigure
     from mpl_toolkits.mplot3d import Axes3D  # noqa: F401

--- a/ros2_unbag/core/utils/pointcloud_video_utils.py
+++ b/ros2_unbag/core/utils/pointcloud_video_utils.py
@@ -27,8 +27,6 @@ Provides helpers for extracting point data from PointCloud2 messages and
 rendering them into BGR image frames suitable for video export.
 """
 
-import struct
-
 import cv2
 import numpy as np
 
@@ -46,14 +44,34 @@ _FIELD_TYPE_MAP = {
     PointField.FLOAT64: ("d", np.float64, 8),
 }
 
+# Per-colormap BGR lookup table cache: computed once, reused for every frame
+_COLORMAP_LUT_CACHE: dict = {}
+
+
+def _get_colormap_lut(cmap_name: str) -> np.ndarray:
+    """Return a cached (256, 3) uint8 BGR LUT for *cmap_name*.
+
+    The LUT is built on the first call for each colormap name and stored in
+    ``_COLORMAP_LUT_CACHE`` so that subsequent frames pay no matplotlib overhead.
+    """
+    if cmap_name not in _COLORMAP_LUT_CACHE:
+        import matplotlib.cm as cm
+        try:
+            cmap = cm.colormaps[cmap_name]       # matplotlib >= 3.7
+        except AttributeError:
+            cmap = cm.get_cmap(cmap_name)        # matplotlib < 3.7
+        indices = np.linspace(0.0, 1.0, 256)
+        rgba = cmap(indices)                          # (256, 4) float64
+        rgb = (rgba[:, :3] * 255).astype(np.uint8)    # (256, 3) uint8
+        _COLORMAP_LUT_CACHE[cmap_name] = rgb[:, ::-1].copy()  # RGB -> BGR
+    return _COLORMAP_LUT_CACHE[cmap_name]
+
+
 # Colormaps available in the GUI combo box (must be valid matplotlib cmap names)
 AVAILABLE_COLORMAPS = [
     "viridis", "jet", "plasma", "inferno", "turbo",
     "magma", "rainbow", "hot", "coolwarm", "hsv",
 ]
-
-# Projection modes available in the GUI combo box
-AVAILABLE_PROJECTIONS = ["topdown", "front", "side", "matplotlib3d"]
 
 
 def extract_field(msg, field_name: str) -> np.ndarray:
@@ -82,17 +100,19 @@ def extract_field(msg, field_name: str) -> np.ndarray:
     if type_info is None:
         raise ValueError(f"Unsupported PointField datatype: {field.datatype}")
 
-    fmt_char, np_dtype, _ = type_info
-    endian = ">" if msg.is_bigendian else "<"
-    full_fmt = endian + fmt_char
+    _fmt_char, np_dtype, byte_size = type_info
+    endian_char = ">" if msg.is_bigendian else "<"
     offset = field.offset
     step = msg.point_step
-    data = msg.data
+    n_points = msg.width * msg.height
 
-    values = np.empty(msg.width * msg.height, dtype=np.float32)
-    for i in range(len(values)):
-        raw = struct.unpack_from(full_fmt, data, i * step + offset)[0]
-        values[i] = float(raw)
+    # Vectorised extraction: build a (n_points, byte_size) uint8 view, then
+    # reinterpret as the target dtype in one shot — no Python loop required.
+    raw_data = np.frombuffer(bytes(msg.data), dtype=np.uint8)
+    point_starts = np.arange(n_points, dtype=np.int64) * step + offset
+    byte_idx = point_starts[:, None] + np.arange(byte_size, dtype=np.int64)[None, :]
+    target_dtype = np.dtype(np_dtype).newbyteorder(endian_char)
+    values = raw_data[byte_idx].reshape(-1).view(target_dtype).astype(np.float32)
 
     return values
 
@@ -130,25 +150,20 @@ def apply_colormap(values: np.ndarray, cmap_name: str, vmin=None, vmax=None) -> 
     Returns:
         numpy.ndarray: Shape (N, 3) uint8 array of BGR colours.
     """
-    import matplotlib.cm as cm
-    import matplotlib.colors as mcolors
-
     finite = values[np.isfinite(values)]
     lo = float(vmin) if vmin is not None else (float(finite.min()) if len(finite) else 0.0)
     hi = float(vmax) if vmax is not None else (float(finite.max()) if len(finite) else 1.0)
     if hi == lo:
         hi = lo + 1.0
 
-    # Explicitly clip: values below lo → lo, values above hi → hi
+    # Map values to [0, 255] LUT indices using the cached BGR LUT.
+    # NaN inputs are suppressed and clamped to index 0 (lowest colour).
+    lut = _get_colormap_lut(cmap_name)
     clipped = np.clip(values, lo, hi)
-
-    norm = mcolors.Normalize(vmin=lo, vmax=hi, clip=False)
-    cmap = cm.get_cmap(cmap_name)
-    # rgba float [0,1] -> uint8 RGB, then swap to BGR
-    rgba = cmap(norm(clipped))  # (N, 4) float
-    rgb = (rgba[:, :3] * 255).astype(np.uint8)
-    bgr = rgb[:, ::-1].copy()  # RGB -> BGR
-    return bgr
+    with np.errstate(invalid="ignore"):
+        idx = ((clipped - lo) / (hi - lo) * 255.0).astype(np.int32)
+    idx = np.clip(idx, 0, 255)
+    return lut[idx]
 
 
 def render_frame(
@@ -160,7 +175,6 @@ def render_frame(
     point_size: int = 2,
     range_min=None,
     range_max=None,
-    projection: str = "topdown",
     x_range: float = 50.0,
     y_range: float = 50.0,
     z_range: float = 10.0,
@@ -171,7 +185,7 @@ def render_frame(
     bg_color: str = "black",
 ) -> np.ndarray:
     """
-    Render a PointCloud2 message into a BGR image frame.
+    Render a PointCloud2 message into a BGR image frame using a 3-D matplotlib scatter plot.
 
     Args:
         msg: PointCloud2 ROS message instance.
@@ -182,14 +196,13 @@ def render_frame(
         point_size (int): Rendered point radius in pixels.
         range_min (float or None): Lower clip bound for color_field values; values below this are clipped to this colour (auto-detect per frame when None).
         range_max (float or None): Upper clip bound for color_field values; values above this are clipped to this colour (auto-detect per frame when None).
-        projection (str): View mode: "topdown", "front", "side", or "matplotlib3d".
         x_range (float): Half-width of the visible scene in metres (x-axis).
         y_range (float): Half-height of the visible scene in metres (y-axis).
-        z_range (float): Half-depth of the visible scene in metres (z-axis, matplotlib3d only).
-        view_azimuth (float): Camera azimuth in degrees (matplotlib3d only).
-        view_elevation (float): Camera elevation in degrees (matplotlib3d only).
-        view_roll (float): Camera roll in degrees (matplotlib3d only).
-        zoom (float): Zoom factor; > 1 zooms in, < 1 zooms out (matplotlib3d only).
+        z_range (float): Half-depth of the visible scene in metres (z-axis).
+        view_azimuth (float): Camera azimuth in degrees.
+        view_elevation (float): Camera elevation in degrees.
+        view_roll (float): Camera roll in degrees.
+        zoom (float): Zoom factor; > 1 zooms in, < 1 zooms out.
         bg_color (str): Background colour, "black" or "white".
 
     Returns:
@@ -197,92 +210,13 @@ def render_frame(
     """
     x, y, z = extract_xyz(msg)
     color_values = extract_field(msg, color_field)
-    bgr_colors = apply_colormap(color_values, colormap, range_min, range_max)
 
-    if projection == "matplotlib3d":
-        return _render_matplotlib3d(
-            x, y, z, color_values, colormap, width, height,
-            point_size, range_min, range_max, view_azimuth, view_elevation,
-            view_roll, zoom, bg_color, x_range, y_range, z_range,
-        )
-
-    # Select which axes to project for each orthographic mode
-    if projection == "topdown":
-        horiz, vert = x, y
-        h_range, v_range = x_range, y_range
-        h_label, v_label = "X", "Y"
-    elif projection == "front":
-        horiz, vert = x, z
-        h_range, v_range = x_range, y_range
-        h_label, v_label = "X", "Z"
-    elif projection == "side":
-        horiz, vert = y, z
-        h_range, v_range = x_range, y_range
-        h_label, v_label = "Y", "Z"
-    else:
-        raise ValueError(
-            f"Unknown projection '{projection}'. "
-            f"Choose from: {AVAILABLE_PROJECTIONS}"
-        )
-
-    return _render_ortho(
-        horiz, vert, bgr_colors, width, height,
-        h_range, v_range, point_size, bg_color,
+    return _render_matplotlib3d(
+        x, y, z, color_values, colormap, width, height,
+        point_size, range_min, range_max, view_azimuth, view_elevation,
+        view_roll, zoom, bg_color, x_range, y_range, z_range,
     )
 
-
-def _render_ortho(
-    horiz: np.ndarray,
-    vert: np.ndarray,
-    bgr_colors: np.ndarray,
-    width: int,
-    height: int,
-    h_range: float,
-    v_range: float,
-    point_size: int,
-    bg_color: str,
-) -> np.ndarray:
-    """
-    Render an orthographic (bird's-eye / front / side) projection to a BGR image.
-
-    Args:
-        horiz (numpy.ndarray): Horizontal axis values (one per point).
-        vert (numpy.ndarray): Vertical axis values (one per point).
-        bgr_colors (numpy.ndarray): (N, 3) uint8 BGR colour per point.
-        width (int): Frame width in pixels.
-        height (int): Frame height in pixels.
-        h_range (float): Half-width of visible range in metres.
-        v_range (float): Half-height of visible range in metres.
-        point_size (int): Point radius in pixels.
-        bg_color (str): "black" or "white".
-
-    Returns:
-        numpy.ndarray: H×W×3 BGR uint8 image.
-    """
-    bg = (0, 0, 0) if bg_color == "black" else (255, 255, 255)
-    img = np.full((height, width, 3), bg, dtype=np.uint8)
-
-    # Pixel coordinates: centre of image = (0, 0) in scene space
-    px = ((horiz / h_range + 1.0) * 0.5 * width).astype(np.int32)
-    py = ((-vert / v_range + 1.0) * 0.5 * height).astype(np.int32)
-
-    # Filter to visible region
-    mask = (px >= 0) & (px < width) & (py >= 0) & (py < height)
-    mask &= np.isfinite(horiz) & np.isfinite(vert)
-
-    px_v = px[mask]
-    py_v = py[mask]
-    colors_v = bgr_colors[mask]
-
-    if point_size <= 1:
-        img[py_v, px_v] = colors_v
-    else:
-        r = max(1, point_size // 2)
-        for i in range(len(px_v)):
-            color = (int(colors_v[i, 0]), int(colors_v[i, 1]), int(colors_v[i, 2]))
-            cv2.circle(img, (int(px_v[i]), int(py_v[i])), r, color, -1, cv2.LINE_AA)
-
-    return img
 
 
 def _render_matplotlib3d(
@@ -333,9 +267,11 @@ def _render_matplotlib3d(
     Returns:
         numpy.ndarray: H×W×3 BGR uint8 image.
     """
-    import matplotlib
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
+    # Use the Agg canvas explicitly so we never touch the global backend
+    # registry (which would conflict with the interactive Qt canvas used by
+    # CameraPreviewDialog when the GUI is running).
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure as MplFigure
     from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 
     dpi = 100
@@ -344,7 +280,8 @@ def _render_matplotlib3d(
 
     bg = "black" if bg_color == "black" else "white"
 
-    fig = plt.figure(figsize=(fig_w, fig_h), dpi=dpi)
+    fig = MplFigure(figsize=(fig_w, fig_h), dpi=dpi)
+    FigureCanvasAgg(fig)  # attach Agg raster backend
     fig.patch.set_facecolor(bg)
     ax = fig.add_subplot(111, projection="3d")
     ax.set_facecolor(bg)
@@ -388,7 +325,6 @@ def _render_matplotlib3d(
 
     buf = np.frombuffer(fig.canvas.buffer_rgba(), dtype=np.uint8)
     buf = buf.reshape(height, width, 4)
-    plt.close(fig)
 
     # RGBA -> BGR
     bgr = buf[:, :, 2::-1].copy()

--- a/ros2_unbag/core/utils/pointcloud_video_utils.py
+++ b/ros2_unbag/core/utils/pointcloud_video_utils.py
@@ -1,0 +1,364 @@
+# MIT License
+
+# Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+PointCloud Video Rendering Utilities.
+
+Provides helpers for extracting point data from PointCloud2 messages and
+rendering them into BGR image frames suitable for video export.
+"""
+
+import struct
+
+import cv2
+import numpy as np
+
+from sensor_msgs.msg import PointField
+
+# Mapping from PointField datatype to (struct_char, numpy_dtype, byte_size)
+_FIELD_TYPE_MAP = {
+    PointField.INT8:    ("b", np.int8,    1),
+    PointField.UINT8:   ("B", np.uint8,   1),
+    PointField.INT16:   ("h", np.int16,   2),
+    PointField.UINT16:  ("H", np.uint16,  2),
+    PointField.INT32:   ("i", np.int32,   4),
+    PointField.UINT32:  ("I", np.uint32,  4),
+    PointField.FLOAT32: ("f", np.float32, 4),
+    PointField.FLOAT64: ("d", np.float64, 8),
+}
+
+# Colormaps available in the GUI combo box (must be valid matplotlib cmap names)
+AVAILABLE_COLORMAPS = [
+    "viridis", "jet", "plasma", "inferno", "turbo",
+    "magma", "rainbow", "hot", "coolwarm", "hsv",
+]
+
+# Projection modes available in the GUI combo box
+AVAILABLE_PROJECTIONS = ["topdown", "front", "side", "matplotlib3d"]
+
+
+def extract_field(msg, field_name: str) -> np.ndarray:
+    """
+    Extract the values of a named field from a PointCloud2 message as a float32 array.
+
+    Args:
+        msg: PointCloud2 ROS message instance.
+        field_name (str): Name of the point field to extract (e.g. "z", "intensity").
+
+    Returns:
+        numpy.ndarray: 1-D float32 array with one value per point, NaN for invalid points.
+
+    Raises:
+        ValueError: If the requested field is not present in the message.
+    """
+    field_by_name = {f.name: f for f in msg.fields}
+    if field_name not in field_by_name:
+        available = list(field_by_name.keys())
+        raise ValueError(
+            f"Field '{field_name}' not found in PointCloud2. Available fields: {available}"
+        )
+
+    field = field_by_name[field_name]
+    type_info = _FIELD_TYPE_MAP.get(field.datatype)
+    if type_info is None:
+        raise ValueError(f"Unsupported PointField datatype: {field.datatype}")
+
+    fmt_char, np_dtype, _ = type_info
+    endian = ">" if msg.is_bigendian else "<"
+    full_fmt = endian + fmt_char
+    offset = field.offset
+    step = msg.point_step
+    data = msg.data
+
+    values = np.empty(msg.width * msg.height, dtype=np.float32)
+    for i in range(len(values)):
+        raw = struct.unpack_from(full_fmt, data, i * step + offset)[0]
+        values[i] = float(raw)
+
+    return values
+
+
+def extract_xyz(msg) -> tuple:
+    """
+    Extract x, y, z coordinate arrays from a PointCloud2 message.
+
+    Args:
+        msg: PointCloud2 ROS message instance.
+
+    Returns:
+        tuple: (x, y, z) each a 1-D float32 numpy array, one element per point.
+
+    Raises:
+        ValueError: If x, y, or z fields are missing.
+    """
+    return extract_field(msg, "x"), extract_field(msg, "y"), extract_field(msg, "z")
+
+
+def apply_colormap(values: np.ndarray, cmap_name: str, vmin=None, vmax=None) -> np.ndarray:
+    """
+    Map scalar values to BGR colours using a matplotlib colormap.
+
+    Args:
+        values (numpy.ndarray): 1-D array of scalar values.
+        cmap_name (str): Matplotlib colormap name (e.g. "jet", "viridis").
+        vmin (float or None): Lower bound for normalisation. Uses array min when None.
+        vmax (float or None): Upper bound for normalisation. Uses array max when None.
+
+    Returns:
+        numpy.ndarray: Shape (N, 3) uint8 array of BGR colours.
+    """
+    import matplotlib.cm as cm
+    import matplotlib.colors as mcolors
+
+    finite = values[np.isfinite(values)]
+    lo = float(vmin) if vmin is not None else (float(finite.min()) if len(finite) else 0.0)
+    hi = float(vmax) if vmax is not None else (float(finite.max()) if len(finite) else 1.0)
+    if hi == lo:
+        hi = lo + 1.0
+
+    norm = mcolors.Normalize(vmin=lo, vmax=hi, clip=True)
+    cmap = cm.get_cmap(cmap_name)
+    # rgba float [0,1] -> uint8 RGB, then swap to BGR
+    rgba = cmap(norm(values))  # (N, 4) float
+    rgb = (rgba[:, :3] * 255).astype(np.uint8)
+    bgr = rgb[:, ::-1].copy()  # RGB -> BGR
+    return bgr
+
+
+def render_frame(
+    msg,
+    color_field: str = "z",
+    colormap: str = "jet",
+    width: int = 1280,
+    height: int = 720,
+    point_size: int = 2,
+    range_min=None,
+    range_max=None,
+    projection: str = "topdown",
+    x_range: float = 50.0,
+    y_range: float = 50.0,
+    view_azimuth: float = 45.0,
+    view_elevation: float = 30.0,
+    bg_color: str = "black",
+) -> np.ndarray:
+    """
+    Render a PointCloud2 message into a BGR image frame.
+
+    Args:
+        msg: PointCloud2 ROS message instance.
+        color_field (str): Point field used to drive the colormap.
+        colormap (str): Matplotlib colormap name.
+        width (int): Output frame width in pixels.
+        height (int): Output frame height in pixels.
+        point_size (int): Rendered point radius in pixels.
+        range_min (float or None): Lower bound for colormap normalisation (auto if None).
+        range_max (float or None): Upper bound for colormap normalisation (auto if None).
+        projection (str): View mode: "topdown", "front", "side", or "matplotlib3d".
+        x_range (float): Half-width of the visible scene in metres (orthographic modes).
+        y_range (float): Half-height of the visible scene in metres (orthographic modes).
+        view_azimuth (float): Camera azimuth in degrees (matplotlib3d only).
+        view_elevation (float): Camera elevation in degrees (matplotlib3d only).
+        bg_color (str): Background colour, "black" or "white".
+
+    Returns:
+        numpy.ndarray: H×W×3 BGR uint8 image.
+    """
+    x, y, z = extract_xyz(msg)
+    color_values = extract_field(msg, color_field)
+    bgr_colors = apply_colormap(color_values, colormap, range_min, range_max)
+
+    if projection == "matplotlib3d":
+        return _render_matplotlib3d(
+            x, y, z, color_values, colormap, width, height,
+            point_size, range_min, range_max, view_azimuth, view_elevation,
+            bg_color,
+        )
+
+    # Select which axes to project for each orthographic mode
+    if projection == "topdown":
+        horiz, vert = x, y
+        h_range, v_range = x_range, y_range
+        h_label, v_label = "X", "Y"
+    elif projection == "front":
+        horiz, vert = x, z
+        h_range, v_range = x_range, y_range
+        h_label, v_label = "X", "Z"
+    elif projection == "side":
+        horiz, vert = y, z
+        h_range, v_range = x_range, y_range
+        h_label, v_label = "Y", "Z"
+    else:
+        raise ValueError(
+            f"Unknown projection '{projection}'. "
+            f"Choose from: {AVAILABLE_PROJECTIONS}"
+        )
+
+    return _render_ortho(
+        horiz, vert, bgr_colors, width, height,
+        h_range, v_range, point_size, bg_color,
+    )
+
+
+def _render_ortho(
+    horiz: np.ndarray,
+    vert: np.ndarray,
+    bgr_colors: np.ndarray,
+    width: int,
+    height: int,
+    h_range: float,
+    v_range: float,
+    point_size: int,
+    bg_color: str,
+) -> np.ndarray:
+    """
+    Render an orthographic (bird's-eye / front / side) projection to a BGR image.
+
+    Args:
+        horiz (numpy.ndarray): Horizontal axis values (one per point).
+        vert (numpy.ndarray): Vertical axis values (one per point).
+        bgr_colors (numpy.ndarray): (N, 3) uint8 BGR colour per point.
+        width (int): Frame width in pixels.
+        height (int): Frame height in pixels.
+        h_range (float): Half-width of visible range in metres.
+        v_range (float): Half-height of visible range in metres.
+        point_size (int): Point radius in pixels.
+        bg_color (str): "black" or "white".
+
+    Returns:
+        numpy.ndarray: H×W×3 BGR uint8 image.
+    """
+    bg = (0, 0, 0) if bg_color == "black" else (255, 255, 255)
+    img = np.full((height, width, 3), bg, dtype=np.uint8)
+
+    # Pixel coordinates: centre of image = (0, 0) in scene space
+    px = ((horiz / h_range + 1.0) * 0.5 * width).astype(np.int32)
+    py = ((-vert / v_range + 1.0) * 0.5 * height).astype(np.int32)
+
+    # Filter to visible region
+    mask = (px >= 0) & (px < width) & (py >= 0) & (py < height)
+    mask &= np.isfinite(horiz) & np.isfinite(vert)
+
+    px_v = px[mask]
+    py_v = py[mask]
+    colors_v = bgr_colors[mask]
+
+    if point_size <= 1:
+        img[py_v, px_v] = colors_v
+    else:
+        r = max(1, point_size // 2)
+        for i in range(len(px_v)):
+            color = (int(colors_v[i, 0]), int(colors_v[i, 1]), int(colors_v[i, 2]))
+            cv2.circle(img, (int(px_v[i]), int(py_v[i])), r, color, -1, cv2.LINE_AA)
+
+    return img
+
+
+def _render_matplotlib3d(
+    x: np.ndarray,
+    y: np.ndarray,
+    z: np.ndarray,
+    color_values: np.ndarray,
+    colormap: str,
+    width: int,
+    height: int,
+    point_size: int,
+    vmin,
+    vmax,
+    azimuth: float,
+    elevation: float,
+    bg_color: str,
+) -> np.ndarray:
+    """
+    Render a 3-D scatter plot of the point cloud via matplotlib and return a BGR image.
+
+    Uses the Agg non-interactive backend so it is safe to call from worker processes.
+
+    Args:
+        x (numpy.ndarray): X coordinates.
+        y (numpy.ndarray): Y coordinates.
+        z (numpy.ndarray): Z coordinates.
+        color_values (numpy.ndarray): Scalar values for colormap.
+        colormap (str): Matplotlib colormap name.
+        width (int): Frame width in pixels.
+        height (int): Frame height in pixels.
+        point_size (int): Marker size in matplotlib points.
+        vmin (float or None): Colormap lower bound.
+        vmax (float or None): Colormap upper bound.
+        azimuth (float): Camera azimuth in degrees.
+        elevation (float): Camera elevation in degrees.
+        bg_color (str): "black" or "white".
+
+    Returns:
+        numpy.ndarray: H×W×3 BGR uint8 image.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+    dpi = 100
+    fig_w = width / dpi
+    fig_h = height / dpi
+
+    bg = "black" if bg_color == "black" else "white"
+    fg = "white" if bg_color == "black" else "black"
+
+    fig = plt.figure(figsize=(fig_w, fig_h), dpi=dpi)
+    fig.patch.set_facecolor(bg)
+    ax = fig.add_subplot(111, projection="3d")
+    ax.set_facecolor(bg)
+
+    finite = np.isfinite(x) & np.isfinite(y) & np.isfinite(z) & np.isfinite(color_values)
+    scatter_kwargs = dict(
+        c=color_values[finite],
+        cmap=colormap,
+        s=max(1, point_size),
+        linewidths=0,
+        alpha=0.85,
+    )
+    if vmin is not None:
+        scatter_kwargs["vmin"] = float(vmin)
+    if vmax is not None:
+        scatter_kwargs["vmax"] = float(vmax)
+
+    ax.scatter(x[finite], y[finite], z[finite], **scatter_kwargs)
+    ax.view_init(elev=elevation, azim=azimuth)
+
+    # Style axes for dark/light background
+    for pane in (ax.xaxis.pane, ax.yaxis.pane, ax.zaxis.pane):
+        pane.set_facecolor(bg)
+        pane.set_edgecolor(fg)
+    ax.tick_params(colors=fg)
+    ax.xaxis.label.set_color(fg)
+    ax.yaxis.label.set_color(fg)
+    ax.zaxis.label.set_color(fg)
+
+    fig.tight_layout(pad=0)
+    fig.canvas.draw()
+
+    buf = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+    buf = buf.reshape(height, width, 3)
+    plt.close(fig)
+
+    # RGB -> BGR
+    bgr = buf[:, :, ::-1].copy()
+    return bgr

--- a/ros2_unbag/core/utils/pointcloud_video_utils.py
+++ b/ros2_unbag/core/utils/pointcloud_video_utils.py
@@ -117,11 +117,15 @@ def apply_colormap(values: np.ndarray, cmap_name: str, vmin=None, vmax=None) -> 
     """
     Map scalar values to BGR colours using a matplotlib colormap.
 
+    Values are clipped to [vmin, vmax] before colormap normalisation, so any
+    point whose color_field value falls outside the specified range will receive
+    the colormap's edge colour (lowest or highest colour).
+
     Args:
         values (numpy.ndarray): 1-D array of scalar values.
         cmap_name (str): Matplotlib colormap name (e.g. "jet", "viridis").
-        vmin (float or None): Lower bound for normalisation. Uses array min when None.
-        vmax (float or None): Upper bound for normalisation. Uses array max when None.
+        vmin (float or None): Lower clip/normalisation bound. Uses array min when None.
+        vmax (float or None): Upper clip/normalisation bound. Uses array max when None.
 
     Returns:
         numpy.ndarray: Shape (N, 3) uint8 array of BGR colours.
@@ -135,10 +139,13 @@ def apply_colormap(values: np.ndarray, cmap_name: str, vmin=None, vmax=None) -> 
     if hi == lo:
         hi = lo + 1.0
 
-    norm = mcolors.Normalize(vmin=lo, vmax=hi, clip=True)
+    # Explicitly clip: values below lo → lo, values above hi → hi
+    clipped = np.clip(values, lo, hi)
+
+    norm = mcolors.Normalize(vmin=lo, vmax=hi, clip=False)
     cmap = cm.get_cmap(cmap_name)
     # rgba float [0,1] -> uint8 RGB, then swap to BGR
-    rgba = cmap(norm(values))  # (N, 4) float
+    rgba = cmap(norm(clipped))  # (N, 4) float
     rgb = (rgba[:, :3] * 255).astype(np.uint8)
     bgr = rgb[:, ::-1].copy()  # RGB -> BGR
     return bgr
@@ -156,8 +163,11 @@ def render_frame(
     projection: str = "topdown",
     x_range: float = 50.0,
     y_range: float = 50.0,
+    z_range: float = 10.0,
     view_azimuth: float = 45.0,
     view_elevation: float = 30.0,
+    view_roll: float = 0.0,
+    zoom: float = 1.0,
     bg_color: str = "black",
 ) -> np.ndarray:
     """
@@ -170,13 +180,16 @@ def render_frame(
         width (int): Output frame width in pixels.
         height (int): Output frame height in pixels.
         point_size (int): Rendered point radius in pixels.
-        range_min (float or None): Lower bound for colormap normalisation (auto if None).
-        range_max (float or None): Upper bound for colormap normalisation (auto if None).
+        range_min (float or None): Lower clip bound for color_field values; values below this are clipped to this colour (auto-detect per frame when None).
+        range_max (float or None): Upper clip bound for color_field values; values above this are clipped to this colour (auto-detect per frame when None).
         projection (str): View mode: "topdown", "front", "side", or "matplotlib3d".
-        x_range (float): Half-width of the visible scene in metres (orthographic modes).
-        y_range (float): Half-height of the visible scene in metres (orthographic modes).
+        x_range (float): Half-width of the visible scene in metres (x-axis).
+        y_range (float): Half-height of the visible scene in metres (y-axis).
+        z_range (float): Half-depth of the visible scene in metres (z-axis, matplotlib3d only).
         view_azimuth (float): Camera azimuth in degrees (matplotlib3d only).
         view_elevation (float): Camera elevation in degrees (matplotlib3d only).
+        view_roll (float): Camera roll in degrees (matplotlib3d only).
+        zoom (float): Zoom factor; > 1 zooms in, < 1 zooms out (matplotlib3d only).
         bg_color (str): Background colour, "black" or "white".
 
     Returns:
@@ -190,7 +203,7 @@ def render_frame(
         return _render_matplotlib3d(
             x, y, z, color_values, colormap, width, height,
             point_size, range_min, range_max, view_azimuth, view_elevation,
-            bg_color,
+            view_roll, zoom, bg_color, x_range, y_range, z_range,
         )
 
     # Select which axes to project for each orthographic mode
@@ -285,7 +298,12 @@ def _render_matplotlib3d(
     vmax,
     azimuth: float,
     elevation: float,
+    roll: float,
+    zoom: float,
     bg_color: str,
+    x_range: float = 50.0,
+    y_range: float = 50.0,
+    z_range: float = 10.0,
 ) -> np.ndarray:
     """
     Render a 3-D scatter plot of the point cloud via matplotlib and return a BGR image.
@@ -301,11 +319,16 @@ def _render_matplotlib3d(
         width (int): Frame width in pixels.
         height (int): Frame height in pixels.
         point_size (int): Marker size in matplotlib points.
-        vmin (float or None): Colormap lower bound.
-        vmax (float or None): Colormap upper bound.
+        vmin (float or None): Lower clip bound for colour values.
+        vmax (float or None): Upper clip bound for colour values.
         azimuth (float): Camera azimuth in degrees.
         elevation (float): Camera elevation in degrees.
+        roll (float): Camera roll in degrees.
+        zoom (float): Zoom factor; > 1 zooms in, < 1 zooms out.
         bg_color (str): "black" or "white".
+        x_range (float): Half-extent for the X axis in metres.
+        y_range (float): Half-extent for the Y axis in metres.
+        z_range (float): Half-extent for the Z axis in metres.
 
     Returns:
         numpy.ndarray: H×W×3 BGR uint8 image.
@@ -320,7 +343,6 @@ def _render_matplotlib3d(
     fig_h = height / dpi
 
     bg = "black" if bg_color == "black" else "white"
-    fg = "white" if bg_color == "black" else "black"
 
     fig = plt.figure(figsize=(fig_w, fig_h), dpi=dpi)
     fig.patch.set_facecolor(bg)
@@ -328,8 +350,16 @@ def _render_matplotlib3d(
     ax.set_facecolor(bg)
 
     finite = np.isfinite(x) & np.isfinite(y) & np.isfinite(z) & np.isfinite(color_values)
+
+    # Explicitly clip color values to [vmin, vmax] before passing to matplotlib
+    clipped_color = color_values.copy()
+    if vmin is not None:
+        clipped_color = np.maximum(clipped_color, float(vmin))
+    if vmax is not None:
+        clipped_color = np.minimum(clipped_color, float(vmax))
+
     scatter_kwargs = dict(
-        c=color_values[finite],
+        c=clipped_color[finite],
         cmap=colormap,
         s=max(1, point_size),
         linewidths=0,
@@ -341,24 +371,25 @@ def _render_matplotlib3d(
         scatter_kwargs["vmax"] = float(vmax)
 
     ax.scatter(x[finite], y[finite], z[finite], **scatter_kwargs)
-    ax.view_init(elev=elevation, azim=azimuth)
+    ax.view_init(elev=elevation, azim=azimuth, roll=roll)
 
-    # Style axes for dark/light background
-    for pane in (ax.xaxis.pane, ax.yaxis.pane, ax.zaxis.pane):
-        pane.set_facecolor(bg)
-        pane.set_edgecolor(fg)
-    ax.tick_params(colors=fg)
-    ax.xaxis.label.set_color(fg)
-    ax.yaxis.label.set_color(fg)
-    ax.zaxis.label.set_color(fg)
+    # Fixed axis limits so the view does not change between frames.
+    # Dividing by zoom shrinks the visible range, producing a zoom-in effect.
+    effective_zoom = max(zoom, 1e-3)
+    ax.set_xlim(-x_range / effective_zoom, x_range / effective_zoom)
+    ax.set_ylim(-y_range / effective_zoom, y_range / effective_zoom)
+    ax.set_zlim(-z_range / effective_zoom, z_range / effective_zoom)
+
+    # Hide all axes, ticks, labels and panes
+    ax.set_axis_off()
 
     fig.tight_layout(pad=0)
     fig.canvas.draw()
 
-    buf = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-    buf = buf.reshape(height, width, 3)
+    buf = np.frombuffer(fig.canvas.buffer_rgba(), dtype=np.uint8)
+    buf = buf.reshape(height, width, 4)
     plt.close(fig)
 
-    # RGB -> BGR
-    bgr = buf[:, :, ::-1].copy()
+    # RGBA -> BGR
+    bgr = buf[:, :, 2::-1].copy()
     return bgr

--- a/ros2_unbag/core/utils/video_utils.py
+++ b/ros2_unbag/core/utils/video_utils.py
@@ -80,9 +80,12 @@ def write_video_frame(ps: dict, img, ts_ns: int, path: Path, fmt: str):
             return
 
         dt_ns = ts_ns - ps["first_ts_ns"]
-        fps = 30.0
-        if dt_ns > 0:
+        if ps.get("target_fps") is not None:
+            fps = ps["target_fps"]
+        elif dt_ns > 0:
             fps = max(1.0, min(240.0, 1e9 / dt_ns))
+        else:
+            fps = 30.0
 
         ps["writer"] = _open_writer(path, fmt, size_hw, fps)
         for f in buf:

--- a/ros2_unbag/core/utils/video_utils.py
+++ b/ros2_unbag/core/utils/video_utils.py
@@ -106,3 +106,4 @@ def finalize_video(ps: dict, path: Path, fmt: str):
         del ps["writer"]
     ps.pop("first_ts_ns", None)
     ps.pop("buffer", None)
+    ps.pop("frame_size", None)

--- a/ros2_unbag/export.py
+++ b/ros2_unbag/export.py
@@ -75,6 +75,13 @@ class ExportCommand(CommandExtension):
             "--cpu-percentage", type=float, default=80.0,
             help="CPU usage for parallel processing")
         parser.add_argument(
+            "--routine-args", action="append", default=None,
+            help=(
+                "Extra arguments for a format-specific routine: /topic:arg=value[,arg2=value2]. "
+                "Can be repeated for different topics. "
+                "Example: --routine-args '/lidar:color_field=intensity,colormap=turbo,width=1920'"
+            ))
+        parser.add_argument(
             "--config", type=str,
             help="Path to config JSON (overrides other args)")
         parser.add_argument(
@@ -306,6 +313,24 @@ class ExportCommand(CommandExtension):
                         processor_args[k.strip()] = v.strip()
                     processor_entry["args"] = processor_args
                 config[topic].setdefault("processors", []).append(processor_entry)
+
+        if args.routine_args:
+            for spec in args.routine_args:
+                if ":" not in spec:
+                    sys.exit(f"Invalid --routine-args (missing ':'): {spec}")
+                topic, _, arg_str = spec.partition(":")
+                if topic not in config:
+                    sys.exit(f"--routine-args topic '{topic}' not found in --export specs.")
+                routine_args = {}
+                for kv in arg_str.split(","):
+                    kv = kv.strip()
+                    if not kv:
+                        continue
+                    if "=" not in kv:
+                        sys.exit(f"Invalid --routine-args entry (expected key=value): '{kv}'")
+                    k, v = kv.split("=", 1)
+                    routine_args[k.strip()] = v.strip()
+                config[topic]["routine_args"] = routine_args
 
         return config
     

--- a/ros2_unbag/ui/main_window.py
+++ b/ros2_unbag/ui/main_window.py
@@ -436,6 +436,7 @@ class UnbagApp(QtWidgets.QMainWindow):
         """
         self._hide_status_progress(f"Loaded {self.bag_path.name}")
         self.bag_reader = reader
+        self.topic_settings.set_bag_path(self.bag_path)
         
         # Populate Topic List
         topics = self.bag_reader.get_topics()

--- a/ros2_unbag/ui/widgets/camera_preview_dialog.py
+++ b/ros2_unbag/ui/widgets/camera_preview_dialog.py
@@ -1,0 +1,644 @@
+# MIT License
+
+# Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Camera Preview Dialog.
+
+Opens the first PointCloud2 frame as an interactive matplotlib 3-D scatter plot
+alongside a live parameter panel.  The panel lets the user edit every relevant
+rendering parameter directly and always stays in sync with the view:
+
+* **Camera group** – azimuth, elevation, roll, zoom: bidirectionally synced
+  with the matplotlib 3-D axes.  Dragging/scrolling the plot updates the
+  spinboxes; editing a spinbox applies the change to the axes instantly
+  *without* rebuilding the scatter plot (fast).
+
+* **Scene Ranges group** – x_range, y_range, z_range: a fast axes limit update
+  happens immediately; a full scatter re-render follows after a short debounce.
+
+* **Color Range group** – range_min, range_max, each with an "auto" checkbox
+  that disables the spinbox and passes ``None`` to the renderer.
+
+* **Appearance group** – bg_color combo.
+
+Clicking "Apply to Settings" emits ``camera_params_applied`` with a dict
+containing **all** editable keys and closes the dialog.
+"""
+
+import numpy as np
+from PySide6 import QtCore, QtWidgets
+
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.figure import Figure
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 – registers the 3d projection
+
+from ros2_unbag.core.utils.pointcloud_video_utils import extract_xyz, extract_field
+from sensor_msgs.msg import PointCloud2
+
+__all__ = ["CameraPreviewDialog"]
+
+_PANEL_WIDTH = 260       # fixed width of the right-hand control panel (px)
+_RERENDER_DELAY_MS = 250  # debounce before full scatter rebuild (ms)
+
+
+class CameraPreviewDialog(QtWidgets.QDialog):
+    """
+    Interactive 3-D point cloud camera preview dialog with a live parameter panel.
+
+    The left side shows the matplotlib scatter canvas with a navigation toolbar.
+    The right side contains editable controls for all render parameters grouped
+    into *Camera*, *Scene Ranges*, *Color Range*, and *Appearance*.
+
+    Camera spinboxes (azim / elev / roll / zoom) are bidirectionally synced
+    with the matplotlib axes:
+
+    * Dragging or scrolling the plot → spinboxes update (no redraw cost).
+    * Editing a spinbox → axes updated via ``view_init`` + ``draw_idle`` (fast,
+      no scatter rebuild).
+
+    Scene ranges, color range, and appearance changes trigger a debounced full
+    scatter re-render that preserves the current view angle.
+
+    Signals:
+        camera_params_applied (dict): Emitted on "Apply to Settings".  Keys:
+            ``view_azimuth``, ``view_elevation``, ``view_roll``, ``zoom``,
+            ``x_range``, ``y_range``, ``z_range``,
+            ``range_min`` (float or None), ``range_max`` (float or None),
+            ``bg_color``.
+    """
+
+    camera_params_applied = QtCore.Signal(dict)
+
+    def __init__(self, msg, args: dict, parent=None):
+        """
+        Initialise the dialog, extract point data, build UI, and render.
+
+        Args:
+            msg: Deserialised PointCloud2 ROS 2 message (first frame).
+            args (dict): Current routine argument values from
+                ``RoutineArgsWidget.get_args()``.  Used to seed all controls.
+            parent: Optional Qt parent widget.
+
+        Returns:
+            None
+        """
+        super().__init__(parent)
+        self.setWindowTitle(
+            "Camera Preview — drag to rotate · scroll to zoom · edit panel values"
+        )
+        self.resize(1220, 780)
+
+        self._msg = msg
+        if not isinstance(msg, PointCloud2):
+            # Conditionally import only if needed to avoid the dependency for non-cloudini-users
+            from ros2_unbag.core.routines.cloudini_pointcloud import decode_cloudini_compressed_pointcloud
+            self._msg = decode_cloudini_compressed_pointcloud(self._msg)
+        self._args = dict(args)
+        self._ax = None
+
+        # Extract point cloud data once; reused by every re-render.
+        self._color_field = str(args.get("color_field", "intensity"))
+        self._px = self._py = self._pz = self._color_values = None
+        self._extract_points()
+
+        # Build UI — all spinboxes get their initial values BEFORE signals are
+        # connected, so no premature callbacks fire during construction.
+        self._init_ui()
+
+        # First render (spinboxes already hold the correct initial values).
+        self._render()
+
+    # ------------------------------------------------------------------
+    # Point extraction (once)
+    # ------------------------------------------------------------------
+
+    def _extract_points(self) -> None:
+        """Extract XYZ + colour field from the ROS message; falls back to z."""
+        try:
+            self._px, self._py, self._pz = extract_xyz(self._msg)
+            self._color_values = extract_field(self._msg, self._color_field)
+        except Exception:
+            try:
+                self._px, self._py, self._pz = extract_xyz(self._msg)
+                self._color_values = self._pz.copy()
+            except Exception:
+                self._px = self._py = self._pz = self._color_values = None
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _init_ui(self) -> None:
+        """Build the full dialog layout."""
+        args = self._args
+        root = QtWidgets.QVBoxLayout(self)
+        root.setContentsMargins(8, 8, 8, 8)
+        root.setSpacing(6)
+
+        # ── top row: canvas (left, expanding) + panel (right, fixed) ────
+        top_row = QtWidgets.QHBoxLayout()
+        top_row.setSpacing(8)
+        root.addLayout(top_row, 1)
+
+        # Canvas column
+        canvas_col = QtWidgets.QVBoxLayout()
+        canvas_col.setSpacing(2)
+        top_row.addLayout(canvas_col, 1)
+
+        self._figure = Figure(figsize=(8, 6), dpi=100)
+        self._canvas = FigureCanvas(self._figure)
+        self._canvas.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
+        self._toolbar = NavigationToolbar(self._canvas, self)
+        canvas_col.addWidget(self._toolbar)
+        canvas_col.addWidget(self._canvas)
+
+        # Right panel (scrollable, fixed width)
+        panel_outer = QtWidgets.QFrame()
+        panel_outer.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        panel_outer.setFixedWidth(_PANEL_WIDTH)
+        panel_outer_layout = QtWidgets.QVBoxLayout(panel_outer)
+        panel_outer_layout.setContentsMargins(0, 0, 0, 0)
+        top_row.addWidget(panel_outer)
+
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QtWidgets.QFrame.NoFrame)
+        panel_outer_layout.addWidget(scroll)
+
+        inner = QtWidgets.QWidget()
+        inner_layout = QtWidgets.QVBoxLayout(inner)
+        inner_layout.setContentsMargins(6, 6, 6, 6)
+        inner_layout.setSpacing(8)
+        scroll.setWidget(inner)
+
+        # ── Group: Camera ─────────────────────────────────────────────────
+        cam_group = QtWidgets.QGroupBox("Camera")
+        cam_form = QtWidgets.QFormLayout(cam_group)
+        cam_form.setSpacing(4)
+        cam_form.setContentsMargins(6, 8, 6, 6)
+
+        self._sb_azim = self._dsb(-360.0, 360.0, 1.0, 1)
+        self._sb_azim.setValue(float(args.get("view_azimuth") or 45.0))
+        cam_form.addRow("Azimuth °", self._sb_azim)
+
+        self._sb_elev = self._dsb(-90.0, 90.0, 1.0, 1)
+        self._sb_elev.setValue(float(args.get("view_elevation") or 30.0))
+        cam_form.addRow("Elevation °", self._sb_elev)
+
+        self._sb_roll = self._dsb(-180.0, 180.0, 1.0, 1)
+        self._sb_roll.setValue(float(args.get("view_roll") or 0.0))
+        cam_form.addRow("Roll °", self._sb_roll)
+
+        self._sb_zoom = self._dsb(0.01, 100.0, 0.1, 3)
+        self._sb_zoom.setValue(float(args.get("zoom") or 1.0))
+        cam_form.addRow("Zoom", self._sb_zoom)
+
+        inner_layout.addWidget(cam_group)
+
+        # ── Group: Scene Ranges ───────────────────────────────────────────
+        range_group = QtWidgets.QGroupBox("Scene Ranges")
+        range_form = QtWidgets.QFormLayout(range_group)
+        range_form.setSpacing(4)
+        range_form.setContentsMargins(6, 8, 6, 6)
+
+        self._sb_xrange = self._dsb(0.1, 1e6, 5.0, 1)
+        self._sb_xrange.setValue(float(args.get("x_range") or 50.0))
+        range_form.addRow("X range (m)", self._sb_xrange)
+
+        self._sb_yrange = self._dsb(0.1, 1e6, 5.0, 1)
+        self._sb_yrange.setValue(float(args.get("y_range") or 50.0))
+        range_form.addRow("Y range (m)", self._sb_yrange)
+
+        self._sb_zrange = self._dsb(0.1, 1e6, 5.0, 1)
+        self._sb_zrange.setValue(float(args.get("z_range") or 10.0))
+        range_form.addRow("Z range (m)", self._sb_zrange)
+
+        inner_layout.addWidget(range_group)
+
+        # ── Group: Color Range ────────────────────────────────────────────
+        color_group = QtWidgets.QGroupBox("Color Range")
+        color_form = QtWidgets.QFormLayout(color_group)
+        color_form.setSpacing(4)
+        color_form.setContentsMargins(6, 8, 6, 6)
+
+        self._sb_rmin = self._dsb(-1e9, 1e9, 1.0, 3)
+        self._cb_rmin_auto = QtWidgets.QCheckBox("auto")
+        rmin_val = args.get("range_min")
+        if rmin_val is None:
+            self._cb_rmin_auto.setChecked(True)
+            self._sb_rmin.setValue(0.0)
+            self._sb_rmin.setEnabled(False)
+        else:
+            self._cb_rmin_auto.setChecked(False)
+            self._sb_rmin.setValue(float(rmin_val))
+        color_form.addRow("Min", self._inline(self._sb_rmin, self._cb_rmin_auto))
+
+        self._sb_rmax = self._dsb(-1e9, 1e9, 1.0, 3)
+        self._cb_rmax_auto = QtWidgets.QCheckBox("auto")
+        rmax_val = args.get("range_max")
+        if rmax_val is None:
+            self._cb_rmax_auto.setChecked(True)
+            self._sb_rmax.setValue(0.0)
+            self._sb_rmax.setEnabled(False)
+        else:
+            self._cb_rmax_auto.setChecked(False)
+            self._sb_rmax.setValue(float(rmax_val))
+        color_form.addRow("Max", self._inline(self._sb_rmax, self._cb_rmax_auto))
+
+        inner_layout.addWidget(color_group)
+
+        # ── Group: Appearance ─────────────────────────────────────────────
+        app_group = QtWidgets.QGroupBox("Appearance")
+        app_form = QtWidgets.QFormLayout(app_group)
+        app_form.setSpacing(4)
+        app_form.setContentsMargins(6, 8, 6, 6)
+
+        self._cb_bgcolor = QtWidgets.QComboBox()
+        self._cb_bgcolor.addItems(["black", "white"])
+        bg_val = str(args.get("bg_color", "black"))
+        self._cb_bgcolor.setCurrentIndex(max(0, self._cb_bgcolor.findText(bg_val)))
+        app_form.addRow("Background", self._cb_bgcolor)
+
+        self._sb_density = QtWidgets.QSpinBox()
+        self._sb_density.setRange(1, 100)
+        self._sb_density.setSingleStep(5)
+        self._sb_density.setSuffix(" %")
+        self._sb_density.setMinimumWidth(80)
+        self._sb_density.setValue(int(args.get("preview_point_density", 10)))
+        self._sb_density.setToolTip(
+            "Percentage of points shown in the preview (lower = faster).\n"
+            "The full dataset is always preserved for export."
+        )
+        app_form.addRow("Point density", self._sb_density)
+
+        self._sb_point_size = QtWidgets.QSpinBox()
+        self._sb_point_size.setRange(1, 50)
+        self._sb_point_size.setSingleStep(1)
+        self._sb_point_size.setMinimumWidth(80)
+        self._sb_point_size.setValue(max(1, int(args.get("point_size") or 2)))
+        app_form.addRow("Point size", self._sb_point_size)
+
+        self._cb_color_field = QtWidgets.QComboBox()
+        self._cb_color_field.setEditable(True)
+        _available_fields = [f.name for f in self._msg.fields]
+        self._cb_color_field.addItems(_available_fields)
+        _cf_idx = self._cb_color_field.findText(self._color_field)
+        if _cf_idx >= 0:
+            self._cb_color_field.setCurrentIndex(_cf_idx)
+        else:
+            self._cb_color_field.setCurrentText(self._color_field)
+        app_form.addRow("Color field", self._cb_color_field)
+
+        self._cb_colormap = QtWidgets.QComboBox()
+        self._cb_colormap.setEditable(True)
+        _common_colormaps = [
+            "viridis", "plasma", "inferno", "magma", "cividis",
+            "turbo", "jet", "hot", "cool", "gray",
+            "RdYlGn", "Spectral", "coolwarm",
+        ]
+        self._cb_colormap.addItems(_common_colormaps)
+        _cm_val = str(args.get("colormap", "viridis"))
+        _cm_idx = self._cb_colormap.findText(_cm_val)
+        if _cm_idx >= 0:
+            self._cb_colormap.setCurrentIndex(_cm_idx)
+        else:
+            self._cb_colormap.setCurrentText(_cm_val)
+        app_form.addRow("Colormap", self._cb_colormap)
+
+        inner_layout.addWidget(app_group)
+        inner_layout.addStretch()
+
+        # ── info bar ──────────────────────────────────────────────────────
+        info = QtWidgets.QLabel(
+            "Drag / scroll the plot  ·  or type values in the panel  ·  "
+            "\u201cApply\u201d writes all parameters back to the settings form"
+        )
+        info.setAlignment(QtCore.Qt.AlignCenter)
+        info.setStyleSheet("color: #6b7280; font-style: italic; padding: 2px;")
+        info.setWordWrap(True)
+        root.addWidget(info)
+
+        # ── bottom buttons ────────────────────────────────────────────────
+        btn_row = QtWidgets.QHBoxLayout()
+        btn_row.addStretch()
+        self._btn_apply = QtWidgets.QPushButton("\u2714  Apply to Settings")
+        self._btn_apply.setDefault(True)
+        self._btn_apply.setMinimumWidth(170)
+        self._btn_apply.clicked.connect(self._apply)
+        btn_row.addWidget(self._btn_apply)
+        btn_cancel = QtWidgets.QPushButton("Cancel")
+        btn_cancel.clicked.connect(self.reject)
+        btn_row.addWidget(btn_cancel)
+        root.addLayout(btn_row)
+
+        # ── connect signals (after all setValue calls) ────────────────────
+
+        # Camera spinboxes → instant axes update (no scatter rebuild)
+        self._sb_azim.valueChanged.connect(self._on_camera_spinbox_changed)
+        self._sb_elev.valueChanged.connect(self._on_camera_spinbox_changed)
+        self._sb_roll.valueChanged.connect(self._on_camera_spinbox_changed)
+        self._sb_zoom.valueChanged.connect(self._on_camera_spinbox_changed)
+
+        # Scene-range spinboxes → instant axes limit update only
+        # (ranges only affect set_xlim/ylim/zlim, not the scatter data)
+        self._sb_xrange.valueChanged.connect(self._on_camera_spinbox_changed)
+        self._sb_yrange.valueChanged.connect(self._on_camera_spinbox_changed)
+        self._sb_zrange.valueChanged.connect(self._on_camera_spinbox_changed)
+
+        # Debounce timer used by color range and appearance changes
+        self._rerender_timer = QtCore.QTimer(self)
+        self._rerender_timer.setSingleShot(True)
+        self._rerender_timer.setInterval(_RERENDER_DELAY_MS)
+        self._rerender_timer.timeout.connect(self._render)
+
+        # Color range spinboxes + auto checkboxes → full re-render only
+        self._sb_rmin.valueChanged.connect(self._schedule_rerender)
+        self._sb_rmax.valueChanged.connect(self._schedule_rerender)
+        self._cb_rmin_auto.stateChanged.connect(
+            lambda s: (self._sb_rmin.setEnabled(s == 0), self._schedule_rerender())
+        )
+        self._cb_rmax_auto.stateChanged.connect(
+            lambda s: (self._sb_rmax.setEnabled(s == 0), self._schedule_rerender())
+        )
+
+        # Appearance → full re-render
+        self._cb_bgcolor.currentTextChanged.connect(self._schedule_rerender)
+        self._sb_density.valueChanged.connect(self._schedule_rerender)
+        self._sb_point_size.valueChanged.connect(self._schedule_rerender)
+        # Color field → re-extract points, then re-render
+        self._cb_color_field.currentTextChanged.connect(self._on_color_field_changed)
+        self._cb_colormap.currentTextChanged.connect(self._schedule_rerender)
+
+        # matplotlib event hooks
+        self._canvas.mpl_connect("button_release_event", self._on_mpl_release)
+        self._canvas.mpl_connect("motion_notify_event", self._on_mpl_motion)
+        self._canvas.mpl_connect(
+            "scroll_event",
+            lambda _e: QtCore.QTimer.singleShot(80, self._sync_spinboxes_from_axes),
+        )
+
+    # ------------------------------------------------------------------
+    # Widget factory helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _dsb(lo: float, hi: float, step: float, decimals: int) -> QtWidgets.QDoubleSpinBox:
+        """Return a ``QDoubleSpinBox`` configured with the given parameters."""
+        sb = QtWidgets.QDoubleSpinBox()
+        sb.setRange(lo, hi)
+        sb.setSingleStep(step)
+        sb.setDecimals(decimals)
+        sb.setMinimumWidth(80)
+        return sb
+
+    @staticmethod
+    def _inline(*widgets) -> QtWidgets.QWidget:
+        """Pack *widgets* side-by-side in a zero-margin container."""
+        w = QtWidgets.QWidget()
+        h = QtWidgets.QHBoxLayout(w)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(4)
+        for i, wgt in enumerate(widgets):
+            h.addWidget(wgt, 1 if i == 0 else 0)
+        return w
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _render(self) -> None:
+        """
+        Fully rebuild the scatter plot using the current panel values.
+
+        Preserves the view angle (azim / elev / roll / zoom) so that a
+        re-render triggered by a color or range change does not reset the
+        user's view.
+
+        Returns:
+            None
+        """
+        if self._px is None:
+            self._show_error("No point data could be extracted from this message.")
+            return
+
+        azimuth   = self._sb_azim.value()
+        elevation = self._sb_elev.value()
+        roll      = self._sb_roll.value()
+        zoom      = max(self._sb_zoom.value(), 1e-3)
+        x_range   = self._sb_xrange.value()
+        y_range   = self._sb_yrange.value()
+        z_range   = self._sb_zrange.value()
+        vmin      = None if self._cb_rmin_auto.isChecked() else self._sb_rmin.value()
+        vmax      = None if self._cb_rmax_auto.isChecked() else self._sb_rmax.value()
+        bg_color  = self._cb_bgcolor.currentText()
+        colormap  = self._cb_colormap.currentText() or "viridis"
+        point_size = self._sb_point_size.value()
+
+        bg = "black" if bg_color == "black" else "white"
+        x, y, z, cv = self._px, self._py, self._pz, self._color_values
+
+        finite = np.isfinite(x) & np.isfinite(y) & np.isfinite(z) & np.isfinite(cv)
+
+        # Subsample for the preview only – the full data arrays are never modified.
+        density = self._sb_density.value() / 100.0
+        if density < 1.0:
+            valid_idx = np.where(finite)[0]
+            n_keep = max(1, int(len(valid_idx) * density))
+            rng = np.random.default_rng(42)  # fixed seed → stable preview
+            chosen = rng.choice(valid_idx, size=n_keep, replace=False)
+            finite = np.zeros(len(x), dtype=bool)
+            finite[chosen] = True
+
+        clipped = cv.copy()
+        if vmin is not None:
+            clipped = np.maximum(clipped, float(vmin))
+        if vmax is not None:
+            clipped = np.minimum(clipped, float(vmax))
+
+        self._figure.clear()
+        self._figure.patch.set_facecolor(bg)
+        ax = self._figure.add_subplot(111, projection="3d")
+        ax.set_facecolor(bg)
+
+        scatter_kwargs: dict = dict(
+            c=clipped[finite], cmap=colormap, s=point_size, linewidths=0, alpha=0.85,
+        )
+        if vmin is not None:
+            scatter_kwargs["vmin"] = float(vmin)
+        if vmax is not None:
+            scatter_kwargs["vmax"] = float(vmax)
+
+        ax.scatter(x[finite], y[finite], z[finite], **scatter_kwargs)
+        ax.view_init(elev=elevation, azim=azimuth, roll=roll)
+        ax.set_xlim(-x_range / zoom, x_range / zoom)
+        ax.set_ylim(-y_range / zoom, y_range / zoom)
+        ax.set_zlim(-z_range / zoom, z_range / zoom)
+        ax.set_box_aspect([1, 1, 1])
+        ax.set_axis_off()
+
+        self._figure.tight_layout(pad=0)
+        self._ax = ax
+        self._canvas.draw()
+
+    def _show_error(self, message: str) -> None:
+        """Replace canvas content with a centred error string."""
+        self._figure.clear()
+        self._figure.text(
+            0.5, 0.5, message,
+            ha="center", va="center", color="red", fontsize=12, wrap=True,
+        )
+        self._canvas.draw()
+
+    def _apply_camera_to_axes(self) -> None:
+        """
+        Push the current camera + range spinbox values to the matplotlib axes
+        and call ``draw_idle``.  Does *not* rebuild the scatter (fast path).
+
+        Returns:
+            None
+        """
+        if self._ax is None:
+            return
+        self._ax.view_init(
+            elev=self._sb_elev.value(),
+            azim=self._sb_azim.value(),
+            roll=self._sb_roll.value(),
+        )
+        zoom = max(self._sb_zoom.value(), 1e-3)
+        xr, yr, zr = self._sb_xrange.value(), self._sb_yrange.value(), self._sb_zrange.value()
+        self._ax.set_xlim(-xr / zoom, xr / zoom)
+        self._ax.set_ylim(-yr / zoom, yr / zoom)
+        self._ax.set_zlim(-zr / zoom, zr / zoom)
+        self._canvas.draw_idle()
+
+    def _sync_spinboxes_from_axes(self) -> None:
+        """
+        Read azim / elev / roll / zoom from the matplotlib axes and update the
+        camera spinboxes.  Uses ``blockSignals`` to avoid re-entrant callbacks.
+
+        Returns:
+            None
+        """
+        if self._ax is None:
+            return
+
+        azim = round(float(self._ax.azim), 1)
+        elev = round(float(self._ax.elev), 1)
+        roll = round(float(getattr(self._ax, "roll", 0.0)), 1)
+
+        xlim = self._ax.get_xlim()
+        half = abs(xlim[1] - xlim[0]) / 2.0
+        zoom = round(self._sb_xrange.value() / half, 3) if half > 1e-6 else 1.0
+
+        for sb, val in (
+            (self._sb_azim, azim),
+            (self._sb_elev, elev),
+            (self._sb_roll, roll),
+            (self._sb_zoom, zoom),
+        ):
+            sb.blockSignals(True)
+            sb.setValue(val)
+            sb.blockSignals(False)
+
+    # ------------------------------------------------------------------
+    # Collect final parameter dict
+    # ------------------------------------------------------------------
+
+    def _collect_params(self) -> dict:
+        """
+        Return all current panel values as a dict ready for
+        ``RoutineArgsWidget.set_args()``.
+
+        Returns:
+            dict: Keys match ``export_pointcloud_video`` argument names.
+        """
+        return {
+            "view_azimuth":   round(self._sb_azim.value(), 1),
+            "view_elevation": round(self._sb_elev.value(), 1),
+            "view_roll":      round(self._sb_roll.value(), 1),
+            "zoom":           round(self._sb_zoom.value(), 3),
+            "x_range":        self._sb_xrange.value(),
+            "y_range":        self._sb_yrange.value(),
+            "z_range":        self._sb_zrange.value(),
+            "range_min":      None if self._cb_rmin_auto.isChecked() else self._sb_rmin.value(),
+            "range_max":      None if self._cb_rmax_auto.isChecked() else self._sb_rmax.value(),
+            "bg_color":       self._cb_bgcolor.currentText(),
+            "point_size":     self._sb_point_size.value(),
+            "color_field":    self._cb_color_field.currentText(),
+            "colormap":       self._cb_colormap.currentText(),
+        }
+
+    # ------------------------------------------------------------------
+    # Signal handlers
+    # ------------------------------------------------------------------
+
+    def _schedule_rerender(self, *_) -> None:
+        """(Re-)start the debounce timer for a full scatter rebuild."""
+        self._rerender_timer.start()
+
+    def _on_camera_spinbox_changed(self, _value=None) -> None:
+        """Apply the updated spinbox value to the axes immediately (fast path)."""
+        self._apply_camera_to_axes()
+
+    def _on_mpl_release(self, _event) -> None:
+        """Sync spinboxes after the user releases the mouse."""
+        self._sync_spinboxes_from_axes()
+
+    def _on_mpl_motion(self, event) -> None:
+        """Sync spinboxes while the user is dragging."""
+        if event.button is not None:
+            self._sync_spinboxes_from_axes()
+
+    def _on_color_field_changed(self, field_name: str) -> None:
+        """
+        Update the active colour field, re-extract colour values from the
+        stored message, and trigger a full re-render.
+
+        Args:
+            field_name (str): Name of the PointCloud2 field to use for colour.
+
+        Returns:
+            None
+        """
+        if not field_name:
+            return
+        self._color_field = field_name
+        self._extract_points()
+        self._render()
+
+    # ------------------------------------------------------------------
+    # Apply / close
+    # ------------------------------------------------------------------
+
+    def _apply(self) -> None:
+        """
+        Emit ``camera_params_applied`` with all current parameter values and
+        close the dialog with an *Accepted* result.
+
+        Returns:
+            None
+        """
+        self.camera_params_applied.emit(self._collect_params())
+        self.accept()

--- a/ros2_unbag/ui/widgets/image_preview_dialog.py
+++ b/ros2_unbag/ui/widgets/image_preview_dialog.py
@@ -1,0 +1,489 @@
+# MIT License
+
+# Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Image Preview Dialog.
+
+Opens the first Image or CompressedImage frame alongside an interactive
+parameter panel.  Supported controls are determined by which parameter keys
+are present in the *args* dict passed from the routine arguments form:
+
+* **resize_width / resize_height** – always shown; live resize preview.
+* **jpeg_quality** – JPEG quality spinbox; the preview encodes and decodes
+  the image in memory so JPEG compression artefacts are visible in real time.
+* **png_compression** – PNG compression level spinbox; PNG is lossless so no
+  visual artefacts, but the output size estimate updates live.
+* **target_fps** – FPS spinbox with "auto" checkbox (video export only).
+
+Clicking "Apply to Settings" emits ``params_applied`` with a dict of all
+currently visible parameter values and closes the dialog.
+"""
+
+import cv2
+import numpy as np
+from PySide6 import QtCore, QtGui, QtWidgets
+
+__all__ = ["ImagePreviewDialog"]
+
+_PANEL_WIDTH = 250
+_UPDATE_DELAY_MS = 120  # debounce before refreshing displayed image
+
+
+class ImagePreviewDialog(QtWidgets.QDialog):
+    """
+    Interactive image preview dialog for Image and CompressedImage export routines.
+
+    The left pane displays the decoded, resized (and, for JPEG export, re-compressed)
+    image so that the effect of every parameter change is immediately visible.
+    The right pane contains controls for all parameters that are present in the
+    *args* dict supplied at construction time.
+
+    Signals:
+        params_applied (dict): Emitted on "Apply to Settings".  Keys match the
+            parameter names of the export routine (e.g. ``resize_width``,
+            ``jpeg_quality``).
+    """
+
+    params_applied = QtCore.Signal(dict)
+
+    def __init__(self, msg, args: dict, parent=None):
+        """
+        Initialise the dialog, decode the first frame, build UI, and render.
+
+        Args:
+            msg: Deserialised ``sensor_msgs/msg/Image`` or
+                ``sensor_msgs/msg/CompressedImage`` ROS 2 message (first frame).
+            args (dict): Current routine argument values from
+                ``RoutineArgsWidget.get_args()``.  Used to seed all controls
+                and to determine which parameter groups to show.
+            parent: Optional Qt parent widget.
+
+        Returns:
+            None
+        """
+        super().__init__(parent)
+        self.setWindowTitle(
+            "Image Preview — edit values on the right · preview updates automatically"
+        )
+        self.resize(1000, 650)
+
+        self._args = dict(args)
+        self._fmt = self._args.pop("__fmt__", "")
+        self._raw_bgr = self._decode_msg(msg)
+
+        # Widget references (set conditionally in _init_ui)
+        self._sb_width = self._auto_w = None
+        self._sb_height = self._auto_h = None
+        self._sb_jpeg_quality = None
+        self._sb_png_compression = None
+        self._sb_fps = self._auto_fps = None
+        self._lbl_out_size = None
+
+        self._init_ui()
+        self._update_preview()
+
+    # ------------------------------------------------------------------
+    # Message decoding
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_msg(msg) -> np.ndarray | None:
+        """Decode a ROS Image or CompressedImage message to a BGR numpy array."""
+        try:
+            # CompressedImage
+            if hasattr(msg, "format") and hasattr(msg, "data") and not hasattr(msg, "encoding"):
+                np_arr = np.frombuffer(msg.data, np.uint8)
+                img = cv2.imdecode(np_arr, cv2.IMREAD_UNCHANGED)
+            else:
+                # sensor_msgs/msg/Image
+                from ros2_unbag.core.utils.image_utils import convert_image
+                raw = np.frombuffer(msg.data, dtype=np.uint8)
+                img = convert_image(raw, msg.encoding, msg.width, msg.height)
+
+            if img is None:
+                return None
+            # Normalise to 3-channel BGR uint8
+            if img.dtype != np.uint8:
+                # Scale 16-bit or float to 8-bit
+                img = cv2.normalize(img, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
+            if img.ndim == 2:
+                img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+            elif img.shape[2] == 4:
+                img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+            return img
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _init_ui(self) -> None:
+        """Build the full dialog layout."""
+        args = self._args
+
+        root = QtWidgets.QVBoxLayout(self)
+        root.setContentsMargins(8, 8, 8, 8)
+        root.setSpacing(6)
+
+        # ── top row: image (left, expanding) + panel (right, fixed) ────
+        top_row = QtWidgets.QHBoxLayout()
+        top_row.setSpacing(8)
+        root.addLayout(top_row, 1)
+
+        # Image display
+        self._img_label = QtWidgets.QLabel()
+        self._img_label.setAlignment(QtCore.Qt.AlignCenter)
+        self._img_label.setMinimumSize(400, 300)
+        self._img_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
+        self._img_label.setStyleSheet("background-color: #111;")
+        top_row.addWidget(self._img_label, 1)
+
+        # Right panel (scrollable, fixed width)
+        panel_frame = QtWidgets.QFrame()
+        panel_frame.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        panel_frame.setFixedWidth(_PANEL_WIDTH)
+        panel_outer = QtWidgets.QVBoxLayout(panel_frame)
+        panel_outer.setContentsMargins(0, 0, 0, 0)
+        top_row.addWidget(panel_frame)
+
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QtWidgets.QFrame.NoFrame)
+        panel_outer.addWidget(scroll)
+
+        inner = QtWidgets.QWidget()
+        inner_layout = QtWidgets.QVBoxLayout(inner)
+        inner_layout.setContentsMargins(6, 6, 6, 6)
+        inner_layout.setSpacing(8)
+        scroll.setWidget(inner)
+
+        # ── Group: Image Info ──────────────────────────────────────────
+        info_group = QtWidgets.QGroupBox("Image Info")
+        info_form = QtWidgets.QFormLayout(info_group)
+        info_form.setSpacing(4)
+        info_form.setContentsMargins(6, 8, 6, 6)
+
+        if self._raw_bgr is not None:
+            oh, ow = self._raw_bgr.shape[:2]
+            info_form.addRow("Original", QtWidgets.QLabel(f"{ow} × {oh} px"))
+        else:
+            info_form.addRow("Original", QtWidgets.QLabel("(decode failed)"))
+
+        self._lbl_out_size = QtWidgets.QLabel("—")
+        info_form.addRow("Output", self._lbl_out_size)
+
+        self._lbl_file_est = QtWidgets.QLabel("—")
+        self._lbl_file_est.setToolTip(
+            "Rough in-memory estimate of the encoded file size."
+        )
+        info_form.addRow("Est. size", self._lbl_file_est)
+
+        inner_layout.addWidget(info_group)
+
+        # ── Group: Resize ──────────────────────────────────────────────
+        resize_group = QtWidgets.QGroupBox("Resize")
+        resize_form = QtWidgets.QFormLayout(resize_group)
+        resize_form.setSpacing(4)
+        resize_form.setContentsMargins(6, 8, 6, 6)
+
+        raw_w = self._raw_bgr.shape[1] if self._raw_bgr is not None else 1920
+        raw_h = self._raw_bgr.shape[0] if self._raw_bgr is not None else 1080
+
+        self._sb_width = QtWidgets.QSpinBox()
+        self._sb_width.setRange(1, 99999)
+        self._auto_w = QtWidgets.QCheckBox("auto")
+        w_val = args.get("resize_width")
+        if w_val is None:
+            self._sb_width.setValue(raw_w)
+            self._sb_width.setEnabled(False)
+            self._auto_w.setChecked(True)
+        else:
+            self._sb_width.setValue(int(w_val))
+            self._auto_w.setChecked(False)
+        resize_form.addRow("Width px", _inline(self._sb_width, self._auto_w))
+
+        self._sb_height = QtWidgets.QSpinBox()
+        self._sb_height.setRange(1, 99999)
+        self._auto_h = QtWidgets.QCheckBox("auto")
+        h_val = args.get("resize_height")
+        if h_val is None:
+            self._sb_height.setValue(raw_h)
+            self._sb_height.setEnabled(False)
+            self._auto_h.setChecked(True)
+        else:
+            self._sb_height.setValue(int(h_val))
+            self._auto_h.setChecked(False)
+        resize_form.addRow("Height px", _inline(self._sb_height, self._auto_h))
+
+        inner_layout.addWidget(resize_group)
+
+        # ── Group: JPEG Quality (image export only) ────────────────────
+        if "jpeg_quality" in args:
+            qual_group = QtWidgets.QGroupBox("JPEG Quality")
+            qual_form = QtWidgets.QFormLayout(qual_group)
+            qual_form.setSpacing(4)
+            qual_form.setContentsMargins(6, 8, 6, 6)
+            self._sb_jpeg_quality = QtWidgets.QSpinBox()
+            self._sb_jpeg_quality.setRange(1, 100)
+            self._sb_jpeg_quality.setSuffix(" %")
+            self._sb_jpeg_quality.setMinimumWidth(80)
+            self._sb_jpeg_quality.setValue(int(args.get("jpeg_quality", 95)))
+            self._sb_jpeg_quality.setToolTip(
+                "JPEG compression quality (1–100).\n"
+                "Lower values produce smaller files but visible artefacts.\n"
+                "The preview re-compresses and decodes the image in memory so\n"
+                "you can see the artefacts before exporting."
+            )
+            qual_form.addRow("Quality", self._sb_jpeg_quality)
+            inner_layout.addWidget(qual_group)
+
+        # ── Group: PNG Compression (image export only) ─────────────────
+        if "png_compression" in args:
+            comp_group = QtWidgets.QGroupBox("PNG Compression")
+            comp_form = QtWidgets.QFormLayout(comp_group)
+            comp_form.setSpacing(4)
+            comp_form.setContentsMargins(6, 8, 6, 6)
+            self._sb_png_compression = QtWidgets.QSpinBox()
+            self._sb_png_compression.setRange(0, 9)
+            self._sb_png_compression.setMinimumWidth(80)
+            self._sb_png_compression.setValue(int(args.get("png_compression", 3)))
+            self._sb_png_compression.setToolTip(
+                "PNG compression level (0 = no compression, 9 = maximum).\n"
+                "PNG is lossless — higher levels produce smaller files at the\n"
+                "cost of longer write time; the image is visually identical."
+            )
+            comp_form.addRow("Level (0–9)", self._sb_png_compression)
+            inner_layout.addWidget(comp_group)
+
+        # ── Group: Frame Rate (video export only) ──────────────────────
+        if "target_fps" in args:
+            fps_group = QtWidgets.QGroupBox("Frame Rate")
+            fps_form = QtWidgets.QFormLayout(fps_group)
+            fps_form.setSpacing(4)
+            fps_form.setContentsMargins(6, 8, 6, 6)
+            self._sb_fps = QtWidgets.QDoubleSpinBox()
+            self._sb_fps.setRange(1.0, 240.0)
+            self._sb_fps.setSingleStep(1.0)
+            self._sb_fps.setDecimals(2)
+            self._sb_fps.setSuffix(" fps")
+            self._sb_fps.setMinimumWidth(80)
+            self._auto_fps = QtWidgets.QCheckBox("auto")
+            fps_val = args.get("target_fps")
+            if fps_val is None:
+                self._sb_fps.setValue(30.0)
+                self._sb_fps.setEnabled(False)
+                self._auto_fps.setChecked(True)
+            else:
+                self._sb_fps.setValue(float(fps_val))
+                self._auto_fps.setChecked(False)
+            self._sb_fps.setToolTip(
+                "Override the auto-detected frame rate.\n"
+                "When set to auto, FPS is inferred from the timestamp\n"
+                "delta between the first two messages."
+            )
+            fps_form.addRow("FPS", _inline(self._sb_fps, self._auto_fps))
+            inner_layout.addWidget(fps_group)
+
+        inner_layout.addStretch()
+
+        # ── info bar ──────────────────────────────────────────────────
+        info_bar = QtWidgets.QLabel(
+            "Edit values in the panel  ·  "
+            "\u201cApply\u201d writes all parameters back to the settings form"
+        )
+        info_bar.setAlignment(QtCore.Qt.AlignCenter)
+        info_bar.setStyleSheet("color: #6b7280; font-style: italic; padding: 2px;")
+        info_bar.setWordWrap(True)
+        root.addWidget(info_bar)
+
+        # ── bottom buttons ────────────────────────────────────────────
+        btn_row = QtWidgets.QHBoxLayout()
+        btn_row.addStretch()
+        btn_apply = QtWidgets.QPushButton("\u2714  Apply to Settings")
+        btn_apply.setDefault(True)
+        btn_apply.setMinimumWidth(160)
+        btn_apply.clicked.connect(self._apply)
+        btn_row.addWidget(btn_apply)
+        btn_cancel = QtWidgets.QPushButton("Cancel")
+        btn_cancel.clicked.connect(self.reject)
+        btn_row.addWidget(btn_cancel)
+        root.addLayout(btn_row)
+
+        # ── debounce timer ────────────────────────────────────────────
+        self._update_timer = QtCore.QTimer(self)
+        self._update_timer.setSingleShot(True)
+        self._update_timer.setInterval(_UPDATE_DELAY_MS)
+        self._update_timer.timeout.connect(self._update_preview)
+
+        # ── connect signals (after all setValue calls) ────────────────
+        self._sb_width.valueChanged.connect(self._schedule_update)
+        self._sb_height.valueChanged.connect(self._schedule_update)
+        self._auto_w.stateChanged.connect(
+            lambda s: (self._sb_width.setEnabled(s == 0), self._schedule_update())
+        )
+        self._auto_h.stateChanged.connect(
+            lambda s: (self._sb_height.setEnabled(s == 0), self._schedule_update())
+        )
+        if self._sb_jpeg_quality is not None:
+            self._sb_jpeg_quality.valueChanged.connect(self._schedule_update)
+        if self._sb_png_compression is not None:
+            self._sb_png_compression.valueChanged.connect(self._schedule_update)
+        if self._sb_fps is not None:
+            self._sb_fps.valueChanged.connect(self._schedule_update)
+            self._auto_fps.stateChanged.connect(
+                lambda s: (self._sb_fps.setEnabled(s == 0), self._schedule_update())
+            )
+
+    # ------------------------------------------------------------------
+    # Preview rendering
+    # ------------------------------------------------------------------
+
+    def _schedule_update(self, *_) -> None:
+        """(Re-)start the debounce timer."""
+        self._update_timer.start()
+
+    def _build_output_image(self) -> np.ndarray | None:
+        """
+        Apply resize (and, if JPEG quality is shown, JPEG round-trip encode) to the
+        cached raw image and return the result as a BGR uint8 array.
+        """
+        if self._raw_bgr is None:
+            return None
+
+        img = self._raw_bgr.copy()
+
+        # Resize
+        w = None if self._auto_w.isChecked() else self._sb_width.value()
+        h = None if self._auto_h.isChecked() else self._sb_height.value()
+        if w is not None or h is not None:
+            orig_h, orig_w = img.shape[:2]
+            if w is None:
+                w = max(1, int(round(orig_w * h / orig_h)))
+            elif h is None:
+                h = max(1, int(round(orig_h * w / orig_w)))
+            img = cv2.resize(img, (int(w), int(h)))
+
+        # JPEG round-trip: only when the selected output format is JPEG so the
+        # user can see compression artefacts in the preview window.
+        if self._sb_jpeg_quality is not None and "jpeg" in self._fmt:
+            quality = self._sb_jpeg_quality.value()
+            ok, buf = cv2.imencode(".jpg", img, [cv2.IMWRITE_JPEG_QUALITY, quality])
+            if ok:
+                img = cv2.imdecode(buf, cv2.IMREAD_COLOR)
+
+        return img
+
+    def _update_preview(self) -> None:
+        """Render the output image and update all info labels."""
+        out = self._build_output_image()
+        if out is None:
+            self._img_label.setText(
+                "<span style='color:#ef4444'>Failed to decode image.</span>"
+            )
+            return
+
+        out_h, out_w = out.shape[:2]
+        self._lbl_out_size.setText(f"{out_w} × {out_h} px")
+
+        # File-size estimate
+        self._lbl_file_est.setText(self._estimate_size(out))
+
+        # Convert BGR → RGB for Qt
+        rgb = cv2.cvtColor(out, cv2.COLOR_BGR2RGB)
+        h, w, ch = rgb.shape
+        qimg = QtGui.QImage(
+            rgb.data.tobytes(), w, h, ch * w, QtGui.QImage.Format_RGB888
+        )
+        pixmap = QtGui.QPixmap.fromImage(qimg)
+
+        # Scale to fit the label while keeping aspect ratio
+        label_size = self._img_label.size()
+        scaled = pixmap.scaled(
+            label_size, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation
+        )
+        self._img_label.setPixmap(scaled)
+
+    def _estimate_size(self, img: np.ndarray) -> str:
+        """Return a human-readable estimate of the encoded file size."""
+        try:
+            if "jpeg" in self._fmt and self._sb_jpeg_quality is not None:
+                quality = self._sb_jpeg_quality.value()
+                ok, buf = cv2.imencode(".jpg", img, [cv2.IMWRITE_JPEG_QUALITY, quality])
+            elif "png" in self._fmt and self._sb_png_compression is not None:
+                level = self._sb_png_compression.value()
+                ok, buf = cv2.imencode(".png", img, [cv2.IMWRITE_PNG_COMPRESSION, level])
+            else:
+                return "—"
+            if not ok:
+                return "—"
+            size = len(buf)
+            if size >= 1024 * 1024:
+                return f"~{size / (1024 * 1024):.1f} MiB"
+            return f"~{size / 1024:.0f} KiB"
+        except Exception:
+            return "—"
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        QtCore.QTimer.singleShot(10, self._update_preview)
+
+    # ------------------------------------------------------------------
+    # Collect params & apply
+    # ------------------------------------------------------------------
+
+    def _collect_params(self) -> dict:
+        """Return all current panel values as a dict for ``RoutineArgsWidget.set_args()``."""
+        params: dict = {}
+        params["resize_width"] = None if self._auto_w.isChecked() else self._sb_width.value()
+        params["resize_height"] = None if self._auto_h.isChecked() else self._sb_height.value()
+        if self._sb_jpeg_quality is not None:
+            params["jpeg_quality"] = self._sb_jpeg_quality.value()
+        if self._sb_png_compression is not None:
+            params["png_compression"] = self._sb_png_compression.value()
+        if self._sb_fps is not None:
+            params["target_fps"] = (
+                None if self._auto_fps.isChecked() else round(self._sb_fps.value(), 3)
+            )
+        return params
+
+    def _apply(self) -> None:
+        """Emit ``params_applied`` and close the dialog."""
+        self.params_applied.emit(self._collect_params())
+        self.accept()
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+def _inline(*widgets) -> QtWidgets.QWidget:
+    """Pack *widgets* side-by-side in a zero-margin container."""
+    w = QtWidgets.QWidget()
+    h = QtWidgets.QHBoxLayout(w)
+    h.setContentsMargins(0, 0, 0, 0)
+    h.setSpacing(4)
+    for i, wgt in enumerate(widgets):
+        h.addWidget(wgt, 1 if i == 0 else 0)
+    return w

--- a/ros2_unbag/ui/widgets/pointcloud_preview_dialog.py
+++ b/ros2_unbag/ui/widgets/pointcloud_preview_dialog.py
@@ -55,13 +55,13 @@ from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 – registers the 3d proje
 from ros2_unbag.core.utils.pointcloud_video_utils import extract_xyz, extract_field
 from sensor_msgs.msg import PointCloud2
 
-__all__ = ["CameraPreviewDialog"]
+__all__ = ["PointcloudPreviewDialog"]
 
 _PANEL_WIDTH = 260       # fixed width of the right-hand control panel (px)
 _RERENDER_DELAY_MS = 250  # debounce before full scatter rebuild (ms)
 
 
-class CameraPreviewDialog(QtWidgets.QDialog):
+class PointcloudPreviewDialog(QtWidgets.QDialog):
     """
     Interactive 3-D point cloud camera preview dialog with a live parameter panel.
 
@@ -80,14 +80,14 @@ class CameraPreviewDialog(QtWidgets.QDialog):
     scatter re-render that preserves the current view angle.
 
     Signals:
-        camera_params_applied (dict): Emitted on "Apply to Settings".  Keys:
+        params_applied (dict): Emitted on "Apply to Settings".  Keys:
             ``view_azimuth``, ``view_elevation``, ``view_roll``, ``zoom``,
             ``x_range``, ``y_range``, ``z_range``,
             ``range_min`` (float or None), ``range_max`` (float or None),
             ``bg_color``.
     """
 
-    camera_params_applied = QtCore.Signal(dict)
+    params_applied = QtCore.Signal(dict)
 
     def __init__(self, msg, args: dict, parent=None):
         """
@@ -634,11 +634,11 @@ class CameraPreviewDialog(QtWidgets.QDialog):
 
     def _apply(self) -> None:
         """
-        Emit ``camera_params_applied`` with all current parameter values and
+        Emit ``params_applied`` with all current parameter values and
         close the dialog with an *Accepted* result.
 
         Returns:
             None
         """
-        self.camera_params_applied.emit(self._collect_params())
+        self.params_applied.emit(self._collect_params())
         self.accept()

--- a/ros2_unbag/ui/widgets/routine_args.py
+++ b/ros2_unbag/ui/widgets/routine_args.py
@@ -38,8 +38,9 @@ Usage in TopicSettingsWidget:
     self.routine_args_widget.set_args({"colormap": "turbo", "width": 1920})
 """
 
+import importlib
 import inspect
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from PySide6 import QtCore, QtWidgets
 
@@ -76,6 +77,133 @@ _PARAM_FLOAT_CONFIG: Dict[str, tuple] = {
     "point_size":     (1.0,    50.0,  1.0,  0),
 }
 
+# ---------------------------------------------------------------------------
+# Preview registry
+# ---------------------------------------------------------------------------
+# Maps (msg_type, canonical_fmt) -> (module_path, class_name, button_label, button_tooltip)
+#
+# The referenced class must be a QDialog subclass with a ``params_applied``
+# signal of type ``Signal(dict)`` and accept ``(msg, args, parent=None)``.
+#
+# Register new preview dialogs by calling ``register_preview_factory()``.
+# This can be done from any module — no changes to this file are required.
+_PREVIEW_REGISTRY: Dict[Tuple[str, str], Tuple[str, str, str, str]] = {}
+
+
+def register_preview_factory(
+    msg_types,
+    fmts,
+    module_path: str,
+    class_name: str,
+    *,
+    label: str = "Preview…",
+    tooltip: str = "Open an interactive preview.",
+) -> None:
+    """
+    Register a preview dialog for one or more (msg_type, format) combinations.
+
+    The dialog class is resolved lazily (on first click) from *module_path* and
+    *class_name*, so heavy dependencies (e.g. matplotlib) are not imported until
+    the user actually opens the preview.
+
+    The dialog must subclass ``QDialog`` and expose::
+
+        params_applied = QtCore.Signal(dict)
+
+    It is constructed as ``factory(msg, args, parent=parent_widget)``.
+
+    Args:
+        msg_types: Single message type string or list of strings.
+        fmts: Single format string or list of format strings (without ``@mode`` suffix).
+        module_path (str): Fully-qualified Python module path, e.g.
+            ``"ros2_unbag.ui.widgets.camera_preview_dialog"``.
+        class_name (str): Class name within *module_path*, e.g. ``"PointcloudPreviewDialog"``.
+        label (str): Text shown on the preview button in the form.
+        tooltip (str): Tooltip shown on the preview button.
+
+    Returns:
+        None
+    """
+    if isinstance(msg_types, str):
+        msg_types = [msg_types]
+    if isinstance(fmts, str):
+        fmts = [fmts]
+    for msg_type in msg_types:
+        for fmt in fmts:
+            _PREVIEW_REGISTRY[(msg_type, fmt)] = (module_path, class_name, label, tooltip)
+
+
+def get_preview_factory(msg_type: str, fmt: str):
+    """
+    Return ``(factory_class, label, tooltip)`` for the given *(msg_type, fmt)*,
+    or ``None`` if no preview is registered.
+
+    The dialog class is imported lazily on first call so that its dependencies
+    are not loaded until actually needed.
+
+    Args:
+        msg_type (str): ROS2 message type string.
+        fmt (str): Export format string (``@mode`` suffix is stripped automatically).
+
+    Returns:
+        tuple or None: ``(class, label, tooltip)`` or ``None``.
+    """
+    canonical = fmt.split("@")[0]
+    spec = _PREVIEW_REGISTRY.get((msg_type, canonical))
+    if spec is None:
+        return None
+    module_path, class_name, label, tooltip = spec
+    factory = getattr(importlib.import_module(module_path), class_name)
+    return factory, label, tooltip
+
+
+# Built-in registrations.
+# Adding a new preview: call register_preview_factory() from your dialog module.
+register_preview_factory(
+    msg_types=[
+        "sensor_msgs/msg/PointCloud2",
+        "point_cloud_interfaces/msg/CompressedPointCloud2",
+    ],
+    fmts=["pointcloud/video_mp4", "pointcloud/video_avi"],
+    module_path="ros2_unbag.ui.widgets.pointcloud_preview_dialog",
+    class_name="PointcloudPreviewDialog",
+    label="Preview Camera",
+    tooltip=(
+        "Open the first point cloud frame as an interactive 3-D scatter plot.\n"
+        "Rotate / zoom the view, then click \u2018Apply to Settings\u2019 to copy\n"
+        "the camera parameters (azimuth, elevation, roll, zoom) into the form."
+    ),
+)
+register_preview_factory(
+    msg_types=[
+        "sensor_msgs/msg/CompressedImage",
+        "sensor_msgs/msg/Image",
+    ],
+    fmts=["image/png", "image/jpeg"],
+    module_path="ros2_unbag.ui.widgets.image_preview_dialog",
+    class_name="ImagePreviewDialog",
+    label="Preview Image",
+    tooltip=(
+        "Open the first image frame to interactively adjust resize,\n"
+        "JPEG quality, and PNG compression level.\n"
+        "JPEG artefacts are visible in the preview before exporting."
+    ),
+)
+register_preview_factory(
+    msg_types=[
+        "sensor_msgs/msg/CompressedImage",
+        "sensor_msgs/msg/Image",
+    ],
+    fmts=["video/mp4", "video/avi"],
+    module_path="ros2_unbag.ui.widgets.image_preview_dialog",
+    class_name="ImagePreviewDialog",
+    label="Preview Frame",
+    tooltip=(
+        "Open the first image frame to interactively adjust resize\n"
+        "and target frame rate before exporting the video."
+    ),
+)
+
 
 class RoutineArgsWidget(QtWidgets.QWidget):
     """
@@ -95,12 +223,16 @@ class RoutineArgsWidget(QtWidgets.QWidget):
 
     Signals:
         args_changed (): Emitted whenever any input value changes.
+        preview_requested (): Emitted when the user clicks the preview button.
+            Only present when a preview factory is registered for the current
+            (msg_type, fmt) combination.
     """
 
     args_changed = QtCore.Signal()
 
-    #: Emitted when the user clicks the "Preview Camera" button (pointcloud video only).
-    preview_camera_requested = QtCore.Signal()
+    #: Emitted when the user clicks the "Preview" button.
+    #: Only connected/relevant when a preview is registered for the current format.
+    preview_requested = QtCore.Signal()
 
     def __init__(self, topic_type: str, fmt: str, parent=None):
         """
@@ -245,16 +377,13 @@ class RoutineArgsWidget(QtWidgets.QWidget):
             else:
                 self._form.addRow(label, row_widget)
 
-        # For pointcloud video formats add a "Preview Camera" button so the user
-        # can interactively set azimuth / elevation / roll / zoom on the first frame.
-        if "pointcloud/video" in self.fmt:
-            self._preview_btn = QtWidgets.QPushButton("Preview Camera")
-            self._preview_btn.setToolTip(
-                "Open the first point cloud frame as an interactive 3-D scatter plot.\n"
-                "Rotate / zoom the view, then click \u2018Apply to Settings\u2019 to copy\n"
-                "the camera parameters (azimuth, elevation, roll, zoom) into the form."
-            )
-            self._preview_btn.clicked.connect(self.preview_camera_requested)
+        # Add a preview button if a preview factory is registered for this format.
+        preview = get_preview_factory(self.topic_type, self.fmt)
+        if preview is not None:
+            _, label, tooltip = preview
+            self._preview_btn = QtWidgets.QPushButton(label)
+            self._preview_btn.setToolTip(tooltip)
+            self._preview_btn.clicked.connect(self.preview_requested)
             self._form.addRow("", self._preview_btn)
 
     def _make_input(

--- a/ros2_unbag/ui/widgets/routine_args.py
+++ b/ros2_unbag/ui/widgets/routine_args.py
@@ -56,6 +56,14 @@ _PARAM_CHOICES: Dict[str, list] = {
     "bg_color": ["black", "white"],
 }
 
+# Parameter-specific int spin box configuration: name → (min, max, step)
+_PARAM_INT_CONFIG: Dict[str, tuple] = {
+    "jpeg_quality":    (1, 100, 1),
+    "png_compression": (0, 9, 1),
+    "resize_width":    (1, 99999, 1),
+    "resize_height":   (1, 99999, 1),
+}
+
 # Parameter-specific float spin box configuration: name → (min, max, step, decimals)
 _PARAM_FLOAT_CONFIG: Dict[str, tuple] = {
     "view_azimuth":   (-180.0, 360.0, 5.0,  1),
@@ -287,15 +295,30 @@ class RoutineArgsWidget(QtWidgets.QWidget):
             cb.stateChanged.connect(self.args_changed)
             return cb, None
 
-        # --- int ---
+        # --- int (and Optional[int]) ---
         if inner is int:
             sb = QtWidgets.QSpinBox()
-            sb.setRange(1, 99999)
-            sb.setSingleStep(1)
-            if default is not None:
+            if name in _PARAM_INT_CONFIG:
+                i_min, i_max, i_step = _PARAM_INT_CONFIG[name]
+                sb.setRange(i_min, i_max)
+                sb.setSingleStep(i_step)
+            else:
+                sb.setRange(1, 99999)
+                sb.setSingleStep(1)
+            auto_check = None
+            if is_optional or default is None:
+                sb.setValue(sb.minimum())
+                sb.setEnabled(False)
+                auto_check = QtWidgets.QCheckBox("auto")
+                auto_check.setChecked(True)
+                auto_check.stateChanged.connect(
+                    lambda state, w=sb: w.setEnabled(state == 0)
+                )
+                auto_check.stateChanged.connect(lambda _: self.args_changed.emit())
+            else:
                 sb.setValue(int(default))
             sb.valueChanged.connect(self.args_changed)
-            return sb, None
+            return sb, auto_check
 
         # --- float (and Optional[float]) ---
         if inner is float:

--- a/ros2_unbag/ui/widgets/routine_args.py
+++ b/ros2_unbag/ui/widgets/routine_args.py
@@ -1,0 +1,341 @@
+# MIT License
+
+# Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Routine Args Widget Module.
+
+Provides RoutineArgsWidget, a dynamic form widget that auto-generates input
+controls for the extra keyword arguments declared by an ExportRoutine function.
+
+The widget mirrors the processor argument pattern: it queries ExportRoutine.get_args()
+for the current message type and format, then builds a labelled row for each parameter
+using an appropriate input control (combo box for known-choice parameters, spin boxes
+for numeric types, checkbox for bool, and a line edit for everything else).
+
+Usage in TopicSettingsWidget:
+    self.routine_args_widget = RoutineArgsWidget(topic_type, fmt)
+    self.routine_args_widget.args_changed.connect(self._emit_change)
+    args_dict = self.routine_args_widget.get_args()   # -> dict[str, Any]
+    self.routine_args_widget.set_args({"colormap": "turbo", "width": 1920})
+"""
+
+import inspect
+from typing import Any, Dict, Optional
+
+from PySide6 import QtCore, QtWidgets
+
+from ros2_unbag.core.routines.base import ExportRoutine
+
+__all__ = ["RoutineArgsWidget"]
+
+# Known enumerated choices for specific parameter names (independent of message type)
+_PARAM_CHOICES: Dict[str, list] = {
+    "colormap": [
+        "viridis", "jet", "plasma", "inferno", "turbo",
+        "magma", "rainbow", "hot", "coolwarm", "hsv",
+    ],
+    "projection": ["topdown", "front", "side", "matplotlib3d"],
+    "bg_color":   ["black", "white"],
+}
+
+
+class RoutineArgsWidget(QtWidgets.QWidget):
+    """
+    Auto-generated form widget for per-format routine keyword arguments.
+
+    Introspects the registered ExportRoutine for the given message type and
+    format, then creates an appropriate input control for each extra parameter
+    beyond the four fixed positional ones (msg, path, fmt, metadata).
+
+    Supported parameter types:
+    - Parameters whose name matches a key in ``_PARAM_CHOICES`` → QComboBox
+    - ``bool`` annotation → QCheckBox
+    - ``int`` annotation → QSpinBox
+    - ``float`` or ``Optional[float]`` annotation → QDoubleSpinBox
+      (with an "auto" checkbox when the default is None)
+    - Everything else → QLineEdit
+
+    Signals:
+        args_changed (): Emitted whenever any input value changes.
+    """
+
+    args_changed = QtCore.Signal()
+
+    def __init__(self, topic_type: str, fmt: str, parent=None):
+        """
+        Initialise the widget and build input controls for the given routine.
+
+        Args:
+            topic_type (str): ROS2 message type string.
+            fmt (str): Export format string.
+            parent: Optional Qt parent widget.
+
+        Returns:
+            None
+        """
+        super().__init__(parent)
+        self.topic_type = topic_type
+        self.fmt = fmt
+        self._inputs: Dict[str, QtWidgets.QWidget] = {}  # param_name -> primary input widget
+        self._auto_checks: Dict[str, QtWidgets.QCheckBox] = {}  # for Optional[float] params
+
+        self._form = QtWidgets.QFormLayout(self)
+        self._form.setContentsMargins(0, 0, 0, 0)
+        self._form.setFieldGrowthPolicy(QtWidgets.QFormLayout.ExpandingFieldsGrow)
+        self._form.setSpacing(4)
+
+        self._build()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_args(self) -> Dict[str, Any]:
+        """
+        Collect current values from all input controls.
+
+        Returns:
+            dict: Mapping of parameter name to its current value.  Optional
+                  float parameters with "auto" checked are returned as None.
+        """
+        result = {}
+        for name, widget in self._inputs.items():
+            # Optional float with auto checkbox
+            if name in self._auto_checks and self._auto_checks[name].isChecked():
+                result[name] = None
+                continue
+
+            if isinstance(widget, QtWidgets.QCheckBox):
+                result[name] = widget.isChecked()
+            elif isinstance(widget, QtWidgets.QSpinBox):
+                result[name] = widget.value()
+            elif isinstance(widget, QtWidgets.QDoubleSpinBox):
+                result[name] = widget.value()
+            elif isinstance(widget, QtWidgets.QComboBox):
+                result[name] = widget.currentText()
+            else:
+                text = widget.text().strip()
+                result[name] = text if text else None
+        return result
+
+    def set_args(self, args: Optional[Dict[str, Any]]) -> None:
+        """
+        Populate input controls from a dictionary of argument values.
+
+        Unknown keys are silently ignored.  None values set the "auto"
+        checkbox (if available) or leave the field at its default.
+
+        Args:
+            args (dict or None): Argument name → value mapping to apply.
+
+        Returns:
+            None
+        """
+        if not args:
+            return
+        for name, value in args.items():
+            if name not in self._inputs:
+                continue
+            widget = self._inputs[name]
+
+            if value is None:
+                if name in self._auto_checks:
+                    self._auto_checks[name].setChecked(True)
+                    self._inputs[name].setEnabled(False)
+                continue
+
+            # Clear auto checkbox if a concrete value is provided
+            if name in self._auto_checks:
+                self._auto_checks[name].setChecked(False)
+                widget.setEnabled(True)
+
+            if isinstance(widget, QtWidgets.QCheckBox):
+                widget.setChecked(bool(value))
+            elif isinstance(widget, QtWidgets.QSpinBox):
+                widget.setValue(int(value))
+            elif isinstance(widget, QtWidgets.QDoubleSpinBox):
+                widget.setValue(float(value))
+            elif isinstance(widget, QtWidgets.QComboBox):
+                idx = widget.findText(str(value))
+                if idx >= 0:
+                    widget.setCurrentIndex(idx)
+                else:
+                    widget.setCurrentText(str(value))
+            else:
+                widget.setText(str(value))
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build(self) -> None:
+        """Build one form row per extra parameter reported by ExportRoutine.get_args()."""
+        args = ExportRoutine.get_args(self.topic_type, self.fmt)
+        if not args:
+            no_args_label = QtWidgets.QLabel("No additional options.")
+            no_args_label.setStyleSheet("color: #6b7280; font-style: italic;")
+            self._form.addRow(no_args_label)
+            return
+
+        for name, (param, doc) in args.items():
+            row_widget, auto_check = self._make_input(name, param, doc)
+            self._inputs[name] = row_widget
+            if auto_check is not None:
+                self._auto_checks[name] = auto_check
+
+            label_text = name
+            if param.default is inspect.Parameter.empty:
+                label_text += " *"  # mark required parameters
+
+            label = QtWidgets.QLabel(label_text)
+            if doc:
+                label.setToolTip(doc)
+                row_widget.setToolTip(doc)
+
+            if auto_check is not None:
+                # Wrap spin box + "auto" checkbox in a horizontal layout
+                container = QtWidgets.QWidget()
+                h = QtWidgets.QHBoxLayout(container)
+                h.setContentsMargins(0, 0, 0, 0)
+                h.setSpacing(6)
+                h.addWidget(row_widget, 1)
+                h.addWidget(auto_check)
+                self._form.addRow(label, container)
+            else:
+                self._form.addRow(label, row_widget)
+
+    def _make_input(
+        self, name: str, param: inspect.Parameter, doc: str
+    ):
+        """
+        Create the appropriate input widget for a single parameter.
+
+        Args:
+            name (str): Parameter name.
+            param (inspect.Parameter): Inspect parameter object.
+            doc (str): Documentation string for the parameter.
+
+        Returns:
+            tuple: (primary_widget, auto_checkbox_or_None)
+        """
+        annotation = param.annotation
+        default = param.default if param.default is not inspect.Parameter.empty else None
+
+        # --- Known-choices combo box ---
+        if name in _PARAM_CHOICES:
+            combo = QtWidgets.QComboBox()
+            combo.addItems(_PARAM_CHOICES[name])
+            if default is not None:
+                idx = combo.findText(str(default))
+                if idx >= 0:
+                    combo.setCurrentIndex(idx)
+            combo.currentTextChanged.connect(self.args_changed)
+            return combo, None
+
+        # Resolve Optional[X] → X
+        inner, is_optional = _unwrap_optional(annotation)
+
+        # --- bool ---
+        if inner is bool:
+            cb = QtWidgets.QCheckBox()
+            cb.setChecked(bool(default) if default is not None else False)
+            cb.stateChanged.connect(self.args_changed)
+            return cb, None
+
+        # --- int ---
+        if inner is int:
+            sb = QtWidgets.QSpinBox()
+            sb.setRange(1, 99999)
+            sb.setSingleStep(1)
+            if default is not None:
+                sb.setValue(int(default))
+            sb.valueChanged.connect(self.args_changed)
+            return sb, None
+
+        # --- float (and Optional[float]) ---
+        if inner is float:
+            dsb = QtWidgets.QDoubleSpinBox()
+            dsb.setRange(-1e9, 1e9)
+            dsb.setDecimals(3)
+            dsb.setSingleStep(1.0)
+            auto_check = None
+            if is_optional or default is None:
+                dsb.setValue(0.0)
+                dsb.setEnabled(False)
+                auto_check = QtWidgets.QCheckBox("auto")
+                auto_check.setChecked(True)
+                auto_check.stateChanged.connect(
+                    lambda state, w=dsb: w.setEnabled(state == 0)
+                )
+                auto_check.stateChanged.connect(lambda _: self.args_changed.emit())
+            else:
+                dsb.setValue(float(default))
+            dsb.valueChanged.connect(self.args_changed)
+            return dsb, auto_check
+
+        # --- fallback: QLineEdit ---
+        le = QtWidgets.QLineEdit()
+        placeholder_parts = []
+        if doc:
+            placeholder_parts.append(doc)
+        if default is not None:
+            placeholder_parts.append(f"default: {default}")
+        if annotation is not inspect.Parameter.empty:
+            type_name = getattr(annotation, "__name__", str(annotation))
+            placeholder_parts.append(f"type: {type_name}")
+        le.setPlaceholderText(" — ".join(placeholder_parts))
+        if default is not None:
+            le.setText(str(default))
+        le.textChanged.connect(self.args_changed)
+        return le, None
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+def _unwrap_optional(annotation):
+    """
+    Detect Optional[X] (i.e. Union[X, None]) and return (inner_type, True).
+    For a plain type return (annotation, False).
+    For inspect.Parameter.empty return (None, False).
+
+    Args:
+        annotation: Type annotation from an inspect.Parameter.
+
+    Returns:
+        tuple: (inner_type_or_None, is_optional: bool)
+    """
+    import typing
+
+    if annotation is inspect.Parameter.empty:
+        return None, False
+
+    origin = getattr(annotation, "__origin__", None)
+    args = getattr(annotation, "__args__", ())
+
+    # typing.Optional[X] == Union[X, None]
+    if origin is typing.Union and len(args) == 2 and type(None) in args:
+        inner = next(a for a in args if a is not type(None))
+        return inner, True
+
+    return annotation, False

--- a/ros2_unbag/ui/widgets/routine_args.py
+++ b/ros2_unbag/ui/widgets/routine_args.py
@@ -57,6 +57,18 @@ _PARAM_CHOICES: Dict[str, list] = {
     "bg_color":   ["black", "white"],
 }
 
+# Parameter-specific float spin box configuration: name → (min, max, step, decimals)
+_PARAM_FLOAT_CONFIG: Dict[str, tuple] = {
+    "view_azimuth":   (-180.0, 360.0, 5.0,  1),
+    "view_elevation": (-90.0,  90.0,  5.0,  1),
+    "view_roll":      (-180.0, 180.0, 5.0,  1),
+    "zoom":           (0.01,   100.0, 0.1,  2),
+    "x_range":        (0.1,    1e6,   5.0,  1),
+    "y_range":        (0.1,    1e6,   5.0,  1),
+    "z_range":        (0.1,    1e6,   5.0,  1),
+    "point_size":     (1.0,    50.0,  1.0,  0),
+}
+
 
 class RoutineArgsWidget(QtWidgets.QWidget):
     """
@@ -274,9 +286,15 @@ class RoutineArgsWidget(QtWidgets.QWidget):
         # --- float (and Optional[float]) ---
         if inner is float:
             dsb = QtWidgets.QDoubleSpinBox()
-            dsb.setRange(-1e9, 1e9)
-            dsb.setDecimals(3)
-            dsb.setSingleStep(1.0)
+            if name in _PARAM_FLOAT_CONFIG:
+                f_min, f_max, f_step, f_dec = _PARAM_FLOAT_CONFIG[name]
+                dsb.setRange(f_min, f_max)
+                dsb.setSingleStep(f_step)
+                dsb.setDecimals(f_dec)
+            else:
+                dsb.setRange(-1e9, 1e9)
+                dsb.setDecimals(3)
+                dsb.setSingleStep(1.0)
             auto_check = None
             if is_optional or default is None:
                 dsb.setValue(0.0)

--- a/ros2_unbag/ui/widgets/routine_args.py
+++ b/ros2_unbag/ui/widgets/routine_args.py
@@ -53,8 +53,7 @@ _PARAM_CHOICES: Dict[str, list] = {
         "viridis", "jet", "plasma", "inferno", "turbo",
         "magma", "rainbow", "hot", "coolwarm", "hsv",
     ],
-    "projection": ["topdown", "front", "side", "matplotlib3d"],
-    "bg_color":   ["black", "white"],
+    "bg_color": ["black", "white"],
 }
 
 # Parameter-specific float spin box configuration: name → (min, max, step, decimals)
@@ -91,6 +90,9 @@ class RoutineArgsWidget(QtWidgets.QWidget):
     """
 
     args_changed = QtCore.Signal()
+
+    #: Emitted when the user clicks the "Preview Camera" button (pointcloud video only).
+    preview_camera_requested = QtCore.Signal()
 
     def __init__(self, topic_type: str, fmt: str, parent=None):
         """
@@ -234,6 +236,18 @@ class RoutineArgsWidget(QtWidgets.QWidget):
                 self._form.addRow(label, container)
             else:
                 self._form.addRow(label, row_widget)
+
+        # For pointcloud video formats add a "Preview Camera" button so the user
+        # can interactively set azimuth / elevation / roll / zoom on the first frame.
+        if "pointcloud/video" in self.fmt:
+            self._preview_btn = QtWidgets.QPushButton("Preview Camera")
+            self._preview_btn.setToolTip(
+                "Open the first point cloud frame as an interactive 3-D scatter plot.\n"
+                "Rotate / zoom the view, then click \u2018Apply to Settings\u2019 to copy\n"
+                "the camera parameters (azimuth, elevation, roll, zoom) into the form."
+            )
+            self._preview_btn.clicked.connect(self.preview_camera_requested)
+            self._form.addRow("", self._preview_btn)
 
     def _make_input(
         self, name: str, param: inspect.Parameter, doc: str

--- a/ros2_unbag/ui/widgets/topic_settings.py
+++ b/ros2_unbag/ui/widgets/topic_settings.py
@@ -90,7 +90,24 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         self.current_topic = None
         self.current_type = None
         self._scroll_area = None  # Will be set when added to scroll area
+        self._bag_path = None     # Set by main_window after loading a bag
         self.init_ui()
+
+    def set_bag_path(self, bag_path) -> None:
+        """
+        Provide the path to the currently loaded bag file.
+
+        Called by the main window whenever a new bag is loaded so that the
+        "Preview Camera" feature can open an independent reader to fetch the
+        first frame for the current topic.
+
+        Args:
+            bag_path: ``pathlib.Path`` (or str) to the ``.db3`` / ``.mcap`` file.
+
+        Returns:
+            None
+        """
+        self._bag_path = bag_path
 
     def init_ui(self):
         """
@@ -504,6 +521,7 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         if extra_args:
             self.routine_args_widget = RoutineArgsWidget(self.current_type, fmt)
             self.routine_args_widget.args_changed.connect(self._emit_change)
+            self.routine_args_widget.preview_camera_requested.connect(self._open_camera_preview)
             self.routine_args_layout.addWidget(self.routine_args_widget)
             self.routine_args_row_label.setVisible(True)
             self.routine_args_container.setVisible(True)
@@ -659,6 +677,89 @@ class TopicSettingsWidget(QtWidgets.QWidget):
             QtCore.Qt.SmoothTransformation
         )
         self.placeholder.setPixmap(scaled)
+
+    def _open_camera_preview(self) -> None:
+        """
+        Read the first PointCloud2 message for the current topic and open
+        ``CameraPreviewDialog`` so the user can interactively set camera
+        parameters.
+
+        A ``QProgressDialog`` is shown while the message is being read from
+        disk.  Any error is surfaced as a ``QMessageBox``.
+
+        Returns:
+            None
+        """
+        if not self._bag_path:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Bag Loaded",
+                "Please load a bag file before opening the camera preview.",
+            )
+            return
+
+        if not self.current_topic:
+            return
+
+        # Show a transient progress dialog while reading the bag
+        progress = QtWidgets.QProgressDialog(
+            f"Reading first frame from '{self.current_topic}'…",
+            None, 0, 0, self,
+        )
+        progress.setWindowModality(QtCore.Qt.WindowModal)
+        progress.setMinimumDuration(0)
+        progress.setValue(0)
+        progress.show()
+        QtWidgets.QApplication.processEvents()
+
+        msg = None
+        try:
+            from ros2_unbag.core.bag_reader import BagReader
+            reader = BagReader(str(self._bag_path))
+            for _, m, _ in reader.read_messages([self.current_topic]):
+                msg = m
+                break
+        except Exception as exc:
+            progress.close()
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Preview Failed",
+                f"Could not read the first message:\n{exc}",
+            )
+            return
+        finally:
+            progress.close()
+
+        if msg is None:
+            QtWidgets.QMessageBox.information(
+                self,
+                "No Messages",
+                f"No messages found for topic '{self.current_topic}'.",
+            )
+            return
+
+        args = self.routine_args_widget.get_args() if self.routine_args_widget else {}
+
+        from ros2_unbag.ui.widgets.camera_preview_dialog import CameraPreviewDialog
+        dlg = CameraPreviewDialog(msg, args, parent=self)
+        dlg.camera_params_applied.connect(self._on_camera_params_applied)
+        dlg.exec()
+
+    def _on_camera_params_applied(self, params: dict) -> None:
+        """
+        Apply camera parameters returned by ``CameraPreviewDialog`` to the
+        routine args form and emit a settings-changed signal.
+
+        Args:
+            params (dict): Dict with keys ``view_azimuth``, ``view_elevation``,
+                ``view_roll``, ``zoom``.
+
+        Returns:
+            None
+        """
+        if self.routine_args_widget:
+            self.routine_args_widget.set_args(params)
+        self._emit_change()
 
     def _emit_change(self):
         """

--- a/ros2_unbag/ui/widgets/topic_settings.py
+++ b/ros2_unbag/ui/widgets/topic_settings.py
@@ -521,7 +521,7 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         if extra_args:
             self.routine_args_widget = RoutineArgsWidget(self.current_type, fmt)
             self.routine_args_widget.args_changed.connect(self._emit_change)
-            self.routine_args_widget.preview_camera_requested.connect(self._open_camera_preview)
+            self.routine_args_widget.preview_requested.connect(self._open_preview)
             self.routine_args_layout.addWidget(self.routine_args_widget)
             self.routine_args_row_label.setVisible(True)
             self.routine_args_container.setVisible(True)
@@ -678,11 +678,15 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         )
         self.placeholder.setPixmap(scaled)
 
-    def _open_camera_preview(self) -> None:
+    def _open_preview(self) -> None:
         """
-        Read the first PointCloud2 message for the current topic and open
-        ``CameraPreviewDialog`` so the user can interactively set camera
-        parameters.
+        Read the first message for the current topic and open the registered
+        preview dialog so the user can interactively adjust export parameters.
+
+        The dialog class is resolved from the preview registry in
+        ``routine_args`` on every call, so the actual module (which may have
+        heavy dependencies such as matplotlib) is only imported the first time
+        the user clicks the button.
 
         A ``QProgressDialog`` is shown while the message is being read from
         disk.  Any error is surfaced as a ``QMessageBox``.
@@ -694,16 +698,22 @@ class TopicSettingsWidget(QtWidgets.QWidget):
             QtWidgets.QMessageBox.warning(
                 self,
                 "No Bag Loaded",
-                "Please load a bag file before opening the camera preview.",
+                "Please load a bag file before opening the preview.",
             )
             return
 
         if not self.current_topic:
             return
 
+        from ros2_unbag.ui.widgets.routine_args import get_preview_factory
+        result = get_preview_factory(self.current_type, self.fmt_combo.currentText())
+        if result is None:
+            return
+        factory, _label, _tooltip = result
+
         # Show a transient progress dialog while reading the bag
         progress = QtWidgets.QProgressDialog(
-            f"Reading first frame from '{self.current_topic}'…",
+            f"Reading first frame from '{self.current_topic}'\u2026",
             None, 0, 0, self,
         )
         progress.setWindowModality(QtCore.Qt.WindowModal)
@@ -739,20 +749,19 @@ class TopicSettingsWidget(QtWidgets.QWidget):
             return
 
         args = self.routine_args_widget.get_args() if self.routine_args_widget else {}
+        args = {**args, "__fmt__": self.fmt_combo.currentText()}
 
-        from ros2_unbag.ui.widgets.camera_preview_dialog import CameraPreviewDialog
-        dlg = CameraPreviewDialog(msg, args, parent=self)
-        dlg.camera_params_applied.connect(self._on_camera_params_applied)
+        dlg = factory(msg, args, parent=self)
+        dlg.params_applied.connect(self._on_preview_params_applied)
         dlg.exec()
 
-    def _on_camera_params_applied(self, params: dict) -> None:
+    def _on_preview_params_applied(self, params: dict) -> None:
         """
-        Apply camera parameters returned by ``CameraPreviewDialog`` to the
-        routine args form and emit a settings-changed signal.
+        Apply parameters returned by a preview dialog to the routine args form
+        and emit a settings-changed signal.
 
         Args:
-            params (dict): Dict with keys ``view_azimuth``, ``view_elevation``,
-                ``view_roll``, ``zoom``.
+            params (dict): Parameter name → value mapping to apply.
 
         Returns:
             None

--- a/ros2_unbag/ui/widgets/topic_settings.py
+++ b/ros2_unbag/ui/widgets/topic_settings.py
@@ -416,8 +416,7 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         if self.chain_widget:
             cfg["processors"] = self.chain_widget.get_chain()
 
-        if self.routine_args_widget:
-            cfg["routine_args"] = self.routine_args_widget.get_args()
+        cfg["routine_args"] = self.routine_args_widget.get_args() if self.routine_args_widget else {}
 
         return cfg
 

--- a/ros2_unbag/ui/widgets/topic_settings.py
+++ b/ros2_unbag/ui/widgets/topic_settings.py
@@ -43,6 +43,7 @@ from ros2_unbag.ui.styles import (
 from ros2_unbag.core.processors import Processor
 from ros2_unbag.core.routines import ExportRoutine, ExportMode
 from .processor_chain import ProcessorChainWidget
+from .routine_args import RoutineArgsWidget
 
 __all__ = ["TopicSettingsWidget"]
 
@@ -170,6 +171,18 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         format_layout.setStretch(0, 1)
         format_layout.setStretch(1, 1)
         self.form_layout.addRow("Format", format_row)
+
+        # Format Options (routine-specific parameters, shown only when the
+        # selected routine declares extra keyword arguments)
+        self.routine_args_container = QtWidgets.QWidget()
+        self.routine_args_layout = QtWidgets.QVBoxLayout(self.routine_args_container)
+        self.routine_args_layout.setContentsMargins(0, 0, 0, 0)
+        self.routine_args_layout.setSpacing(0)
+        self.routine_args_row_label = QtWidgets.QLabel("Format Options")
+        self.form_layout.addRow(self.routine_args_row_label, self.routine_args_container)
+        self.routine_args_row_label.setVisible(False)
+        self.routine_args_container.setVisible(False)
+        self.routine_args_widget = None
 
         # Output Directory
         self.path_edit = QtWidgets.QLineEdit()
@@ -320,6 +333,11 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         # 2. Update Mode options based on format
         self._refresh_mode_controls(self.fmt_combo.currentText())
 
+        # 2b. Rebuild routine args widget for the current format
+        self._rebuild_routine_args(self.fmt_combo.currentText())
+        if self.routine_args_widget and config.get("routine_args"):
+            self.routine_args_widget.set_args(config["routine_args"])
+
         # 3. Set other fields
         self.path_edit.setText(config.get("path", str(self.default_folder)))
         subdir_value = config.get("subfolder", "%name")
@@ -397,7 +415,10 @@ class TopicSettingsWidget(QtWidgets.QWidget):
         
         if self.chain_widget:
             cfg["processors"] = self.chain_widget.get_chain()
-            
+
+        if self.routine_args_widget:
+            cfg["routine_args"] = self.routine_args_widget.get_args()
+
         return cfg
 
     def set_export_state(self, checked: bool):
@@ -451,7 +472,45 @@ class TopicSettingsWidget(QtWidgets.QWidget):
             None
         """
         self._refresh_mode_controls(text)
+        self._rebuild_routine_args(text)
         self._emit_change()
+
+    def _rebuild_routine_args(self, fmt: str) -> None:
+        """
+        Rebuild the RoutineArgsWidget for the currently selected format.
+
+        Clears any existing widget, queries ExportRoutine.get_args() for the
+        new format and, if extra arguments are declared, creates a new
+        RoutineArgsWidget and adds it to the form.
+
+        Args:
+            fmt (str): The newly selected export format string.
+
+        Returns:
+            None
+        """
+        # Remove the old widget
+        while self.routine_args_layout.count():
+            item = self.routine_args_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self.routine_args_widget = None
+
+        if not self.current_type:
+            self.routine_args_row_label.setVisible(False)
+            self.routine_args_container.setVisible(False)
+            return
+
+        extra_args = ExportRoutine.get_args(self.current_type, fmt)
+        if extra_args:
+            self.routine_args_widget = RoutineArgsWidget(self.current_type, fmt)
+            self.routine_args_widget.args_changed.connect(self._emit_change)
+            self.routine_args_layout.addWidget(self.routine_args_widget)
+            self.routine_args_row_label.setVisible(True)
+            self.routine_args_container.setVisible(True)
+        else:
+            self.routine_args_row_label.setVisible(False)
+            self.routine_args_container.setVisible(False)
 
     def _on_mode_changed(self, idx):
         """

--- a/tests/test_pointcloud_video.py
+++ b/tests/test_pointcloud_video.py
@@ -1,0 +1,331 @@
+# MIT License
+
+# Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Tests for the PointCloud-to-video export routine and its rendering utilities.
+"""
+
+import struct
+import tempfile
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+import ros2_unbag.core.routines  # ensure all routines are registered
+
+from ros2_unbag.core.routines.base import ExportRoutine, ExportMetadata
+from ros2_unbag.core.utils.pointcloud_video_utils import (
+    extract_field,
+    extract_xyz,
+    apply_colormap,
+    render_frame,
+    AVAILABLE_COLORMAPS,
+    AVAILABLE_PROJECTIONS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build synthetic PointCloud2 messages
+# ---------------------------------------------------------------------------
+
+def _make_pc2(points: list, fields_order=("x", "y", "z", "intensity")):
+    """
+    Create a minimal synthetic sensor_msgs/PointCloud2 message for testing.
+
+    Args:
+        points: List of dicts with field-name → float value per point.
+        fields_order: Field names in declaration order.
+
+    Returns:
+        A mock PointCloud2-like object with the same API as the real one.
+    """
+    from sensor_msgs.msg import PointCloud2, PointField
+
+    DTYPE_MAP = {
+        "x": PointField.FLOAT32,
+        "y": PointField.FLOAT32,
+        "z": PointField.FLOAT32,
+        "intensity": PointField.FLOAT32,
+        "ring": PointField.UINT16,
+    }
+    STRUCT_MAP = {
+        PointField.FLOAT32: ("f", 4),
+        PointField.UINT16: ("H", 2),
+    }
+
+    # Build fields list
+    fields = []
+    offset = 0
+    field_meta = {}
+    for name in fields_order:
+        dt = DTYPE_MAP[name]
+        _, size = STRUCT_MAP[dt]
+        field = PointField()
+        field.name = name
+        field.offset = offset
+        field.datatype = dt
+        field.count = 1
+        fields.append(field)
+        field_meta[name] = (dt, offset, size)
+        offset += size
+
+    point_step = offset
+
+    # Pack binary data
+    data = bytearray()
+    for pt in points:
+        row = bytearray(point_step)
+        for name, (dt, off, size) in field_meta.items():
+            fmt_char = STRUCT_MAP[dt][0]
+            val = pt.get(name, 0.0)
+            struct.pack_into(f"<{fmt_char}", row, off, val)
+        data.extend(row)
+
+    msg = PointCloud2()
+    msg.height = 1
+    msg.width = len(points)
+    msg.fields = fields
+    msg.is_bigendian = False
+    msg.point_step = point_step
+    msg.row_step = point_step * len(points)
+    msg.is_dense = True
+    msg.data = bytes(data)
+
+    # Inject a fake header with a timestamp
+    from std_msgs.msg import Header
+    from builtin_interfaces.msg import Time
+    h = Header()
+    t = Time()
+    t.sec = 1000
+    t.nanosec = 0
+    h.stamp = t
+    msg.header = h
+
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: extract_field
+# ---------------------------------------------------------------------------
+
+class TestExtractField:
+    def test_extracts_z(self):
+        pts = [{"x": 1.0, "y": 2.0, "z": 3.0, "intensity": 10.0},
+               {"x": 4.0, "y": 5.0, "z": 6.0, "intensity": 20.0}]
+        msg = _make_pc2(pts)
+        values = extract_field(msg, "z")
+        np.testing.assert_allclose(values, [3.0, 6.0], atol=1e-5)
+
+    def test_extracts_intensity(self):
+        pts = [{"x": 0.0, "y": 0.0, "z": 0.0, "intensity": 42.0}]
+        msg = _make_pc2(pts)
+        values = extract_field(msg, "intensity")
+        np.testing.assert_allclose(values, [42.0], atol=1e-5)
+
+    def test_missing_field_raises(self):
+        pts = [{"x": 0.0, "y": 0.0, "z": 0.0, "intensity": 0.0}]
+        msg = _make_pc2(pts)
+        with pytest.raises(ValueError, match="nonexistent"):
+            extract_field(msg, "nonexistent")
+
+    def test_extract_xyz(self):
+        pts = [{"x": 1.0, "y": 2.0, "z": 3.0, "intensity": 0.0},
+               {"x": -1.0, "y": -2.0, "z": -3.0, "intensity": 0.0}]
+        msg = _make_pc2(pts)
+        x, y, z = extract_xyz(msg)
+        np.testing.assert_allclose(x, [1.0, -1.0], atol=1e-5)
+        np.testing.assert_allclose(y, [2.0, -2.0], atol=1e-5)
+        np.testing.assert_allclose(z, [3.0, -3.0], atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: apply_colormap
+# ---------------------------------------------------------------------------
+
+class TestApplyColormap:
+    def test_output_shape(self):
+        values = np.linspace(0.0, 1.0, 10, dtype=np.float32)
+        bgr = apply_colormap(values, "jet")
+        assert bgr.shape == (10, 3)
+        assert bgr.dtype == np.uint8
+
+    def test_range_clipping(self):
+        values = np.array([0.0, 5.0, 10.0], dtype=np.float32)
+        bgr_full = apply_colormap(values, "jet", vmin=0.0, vmax=10.0)
+        assert bgr_full.shape == (3, 3)
+
+    def test_all_colormaps_run(self):
+        values = np.linspace(0.0, 1.0, 5, dtype=np.float32)
+        for cmap in AVAILABLE_COLORMAPS:
+            result = apply_colormap(values, cmap)
+            assert result.shape == (5, 3)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: render_frame (orthographic)
+# ---------------------------------------------------------------------------
+
+class TestRenderFrame:
+    def _simple_msg(self):
+        pts = [{"x": float(i), "y": float(i), "z": float(i), "intensity": float(i)}
+               for i in range(100)]
+        return _make_pc2(pts)
+
+    def test_output_shape_topdown(self):
+        msg = self._simple_msg()
+        img = render_frame(msg, projection="topdown", width=320, height=240)
+        assert img.shape == (240, 320, 3)
+        assert img.dtype == np.uint8
+
+    def test_output_shape_front(self):
+        msg = self._simple_msg()
+        img = render_frame(msg, projection="front", width=320, height=240)
+        assert img.shape == (240, 320, 3)
+
+    def test_output_shape_side(self):
+        msg = self._simple_msg()
+        img = render_frame(msg, projection="side", width=320, height=240)
+        assert img.shape == (240, 320, 3)
+
+    def test_black_background(self):
+        # Background pixels should be (0,0,0) for bg_color="black"
+        pts = [{"x": 1000.0, "y": 1000.0, "z": 1000.0, "intensity": 0.0}]
+        msg = _make_pc2(pts)
+        img = render_frame(msg, projection="topdown", width=64, height=64,
+                           bg_color="black", x_range=1.0, y_range=1.0)
+        # All points are out of range, so entire frame should be black
+        assert np.all(img == 0)
+
+    def test_white_background(self):
+        pts = [{"x": 1000.0, "y": 1000.0, "z": 1000.0, "intensity": 0.0}]
+        msg = _make_pc2(pts)
+        img = render_frame(msg, projection="topdown", width=64, height=64,
+                           bg_color="white", x_range=1.0, y_range=1.0)
+        assert np.all(img == 255)
+
+    def test_invalid_projection(self):
+        msg = self._simple_msg()
+        with pytest.raises(ValueError, match="projection"):
+            render_frame(msg, projection="invalid")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: ExportRoutine.get_args for the new routine
+# ---------------------------------------------------------------------------
+
+class TestRoutineGetArgs:
+    def test_get_args_returns_dict(self):
+        args = ExportRoutine.get_args(
+            "sensor_msgs/msg/PointCloud2", "pointcloud/video_mp4"
+        )
+        assert isinstance(args, dict)
+
+    def test_expected_params_present(self):
+        args = ExportRoutine.get_args(
+            "sensor_msgs/msg/PointCloud2", "pointcloud/video_mp4"
+        )
+        for expected in (
+            "color_field", "colormap", "width", "height", "point_size",
+            "range_min", "range_max", "projection",
+            "x_range", "y_range", "view_azimuth", "view_elevation", "bg_color",
+        ):
+            assert expected in args, f"Missing parameter: {expected}"
+
+    def test_fixed_args_not_exposed(self):
+        args = ExportRoutine.get_args(
+            "sensor_msgs/msg/PointCloud2", "pointcloud/video_mp4"
+        )
+        for forbidden in ("msg", "path", "fmt", "metadata"):
+            assert forbidden not in args
+
+    def test_defaults_are_set(self):
+        import inspect as _inspect
+        args = ExportRoutine.get_args(
+            "sensor_msgs/msg/PointCloud2", "pointcloud/video_mp4"
+        )
+        param_colormap, _ = args["colormap"]
+        assert param_colormap.default == "jet"
+        param_w, _ = args["width"]
+        assert param_w.default == 1280
+
+
+# ---------------------------------------------------------------------------
+# Integration test: routine produces a valid video file
+# ---------------------------------------------------------------------------
+
+class TestExportPointcloudVideoIntegration:
+    def test_single_frame_produces_video(self, tmp_path):
+        pts = [{"x": float(i * 0.5 - 10), "y": float(j * 0.5 - 10), "z": float(i + j),
+                "intensity": float(i * j)}
+               for i in range(20) for j in range(20)]
+        msg = _make_pc2(pts)
+
+        from ros2_unbag.core.routines.pointcloud_video import export_pointcloud_video
+
+        out_path = tmp_path / "test_pc_video"
+        metadata = ExportMetadata(index=0, max_index=0)
+
+        export_pointcloud_video(
+            msg, out_path, "pointcloud/video_mp4", metadata,
+            width=320, height=240, point_size=2,
+            projection="topdown", x_range=15.0, y_range=15.0,
+        )
+
+        result = tmp_path / "test_pc_video.mp4"
+        assert result.exists(), "Expected .mp4 output not created"
+        assert result.stat().st_size > 0
+
+        cap = cv2.VideoCapture(str(result))
+        assert cap.isOpened()
+        ret, frame = cap.read()
+        assert ret, "Could not read a frame from the output video"
+        assert frame.shape == (240, 320, 3)
+        cap.release()
+
+    def test_multi_frame_video(self, tmp_path):
+        def make_msg(z_offset):
+            pts = [{"x": float(i - 5), "y": float(j - 5), "z": float(i + j + z_offset),
+                    "intensity": float(i)}
+                   for i in range(10) for j in range(10)]
+            return _make_pc2(pts)
+
+        from ros2_unbag.core.routines.pointcloud_video import export_pointcloud_video
+
+        out_path = tmp_path / "multi_frame"
+        n_frames = 5
+        for idx in range(n_frames):
+            msg = make_msg(float(idx))
+            metadata = ExportMetadata(index=idx, max_index=n_frames - 1)
+            export_pointcloud_video(
+                msg, out_path, "pointcloud/video_mp4", metadata,
+                width=160, height=120, color_field="z",
+                colormap="viridis", projection="topdown",
+            )
+
+        result = tmp_path / "multi_frame.mp4"
+        assert result.exists()
+        cap = cv2.VideoCapture(str(result))
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        cap.release()
+        assert frame_count == n_frames

--- a/tests/test_pointcloud_video.py
+++ b/tests/test_pointcloud_video.py
@@ -166,13 +166,13 @@ class TestExtractField:
 class TestApplyColormap:
     def test_output_shape(self):
         values = np.linspace(0.0, 1.0, 10, dtype=np.float32)
-        bgr = apply_colormap(values, "jet")
+        bgr = apply_colormap(values, "viridis")
         assert bgr.shape == (10, 3)
         assert bgr.dtype == np.uint8
 
     def test_range_clipping(self):
         values = np.array([0.0, 5.0, 10.0], dtype=np.float32)
-        bgr_full = apply_colormap(values, "jet", vmin=0.0, vmax=10.0)
+        bgr_full = apply_colormap(values, "viridis", vmin=0.0, vmax=10.0)
         assert bgr_full.shape == (3, 3)
 
     def test_all_colormaps_run(self):
@@ -265,7 +265,7 @@ class TestRoutineGetArgs:
             "sensor_msgs/msg/PointCloud2", "pointcloud/video_mp4"
         )
         param_colormap, _ = args["colormap"]
-        assert param_colormap.default == "jet"
+        assert param_colormap.default == "viridis"
         param_w, _ = args["width"]
         assert param_w.default == 1280
 

--- a/tests/test_pointcloud_video.py
+++ b/tests/test_pointcloud_video.py
@@ -41,8 +41,8 @@ from ros2_unbag.core.utils.pointcloud_video_utils import (
     apply_colormap,
     render_frame,
     AVAILABLE_COLORMAPS,
-    AVAILABLE_PROJECTIONS,
 )
+
 
 
 # ---------------------------------------------------------------------------
@@ -183,7 +183,7 @@ class TestApplyColormap:
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: render_frame (orthographic)
+# Unit tests: render_frame (matplotlib3d)
 # ---------------------------------------------------------------------------
 
 class TestRenderFrame:
@@ -192,42 +192,34 @@ class TestRenderFrame:
                for i in range(100)]
         return _make_pc2(pts)
 
-    def test_output_shape_topdown(self):
+    def test_output_shape(self):
         msg = self._simple_msg()
-        img = render_frame(msg, projection="topdown", width=320, height=240)
+        img = render_frame(msg, width=320, height=240)
         assert img.shape == (240, 320, 3)
         assert img.dtype == np.uint8
 
-    def test_output_shape_front(self):
-        msg = self._simple_msg()
-        img = render_frame(msg, projection="front", width=320, height=240)
-        assert img.shape == (240, 320, 3)
-
-    def test_output_shape_side(self):
-        msg = self._simple_msg()
-        img = render_frame(msg, projection="side", width=320, height=240)
-        assert img.shape == (240, 320, 3)
-
     def test_black_background(self):
-        # Background pixels should be (0,0,0) for bg_color="black"
-        pts = [{"x": 1000.0, "y": 1000.0, "z": 1000.0, "intensity": 0.0}]
-        msg = _make_pc2(pts)
-        img = render_frame(msg, projection="topdown", width=64, height=64,
-                           bg_color="black", x_range=1.0, y_range=1.0)
-        # All points are out of range, so entire frame should be black
-        assert np.all(img == 0)
+        msg = self._simple_msg()
+        img = render_frame(msg, width=64, height=64, bg_color="black")
+        assert img.dtype == np.uint8
+        assert img.shape == (64, 64, 3)
+        # The matplotlib canvas should be predominantly black
+        assert img[0, 0].tolist() == [0, 0, 0]
 
     def test_white_background(self):
-        pts = [{"x": 1000.0, "y": 1000.0, "z": 1000.0, "intensity": 0.0}]
-        msg = _make_pc2(pts)
-        img = render_frame(msg, projection="topdown", width=64, height=64,
-                           bg_color="white", x_range=1.0, y_range=1.0)
-        assert np.all(img == 255)
-
-    def test_invalid_projection(self):
         msg = self._simple_msg()
-        with pytest.raises(ValueError, match="projection"):
-            render_frame(msg, projection="invalid")
+        img = render_frame(msg, width=64, height=64, bg_color="white")
+        assert img.dtype == np.uint8
+        assert img.shape == (64, 64, 3)
+        # The matplotlib canvas corners should be white
+        assert img[0, 0].tolist() == [255, 255, 255]
+
+    def test_view_angle_changes_output(self):
+        """Different azimuth values should produce different images."""
+        msg = self._simple_msg()
+        img_a = render_frame(msg, width=128, height=96, view_azimuth=0.0)
+        img_b = render_frame(msg, width=128, height=96, view_azimuth=90.0)
+        assert not np.array_equal(img_a, img_b)
 
 
 # ---------------------------------------------------------------------------
@@ -247,10 +239,17 @@ class TestRoutineGetArgs:
         )
         for expected in (
             "color_field", "colormap", "width", "height", "point_size",
-            "range_min", "range_max", "projection",
-            "x_range", "y_range", "view_azimuth", "view_elevation", "bg_color",
+            "range_min", "range_max",
+            "x_range", "y_range", "z_range",
+            "view_azimuth", "view_elevation", "view_roll", "zoom", "bg_color",
         ):
             assert expected in args, f"Missing parameter: {expected}"
+
+    def test_projection_not_exposed(self):
+        args = ExportRoutine.get_args(
+            "sensor_msgs/msg/PointCloud2", "pointcloud/video_mp4"
+        )
+        assert "projection" not in args, "projection should no longer be an exposed parameter"
 
     def test_fixed_args_not_exposed(self):
         args = ExportRoutine.get_args(
@@ -289,7 +288,7 @@ class TestExportPointcloudVideoIntegration:
         export_pointcloud_video(
             msg, out_path, "pointcloud/video_mp4", metadata,
             width=320, height=240, point_size=2,
-            projection="topdown", x_range=15.0, y_range=15.0,
+            x_range=15.0, y_range=15.0,
         )
 
         result = tmp_path / "test_pc_video.mp4"
@@ -320,7 +319,7 @@ class TestExportPointcloudVideoIntegration:
             export_pointcloud_video(
                 msg, out_path, "pointcloud/video_mp4", metadata,
                 width=160, height=120, color_field="z",
-                colormap="viridis", projection="topdown",
+                colormap="viridis",
             )
 
         result = tmp_path / "multi_frame.mp4"


### PR DESCRIPTION
This pull request introduces a new export routine for rendering ROS 2 PointCloud2 messages as colorized videos.

Since those usually are heavily parameterized, it adds support for customizable routine arguments as a major change. Applied to the point cloud video export, parameters such as colormap, camera angle, and output size are configurable via configuration files, the GUI, or CLI.

**New PointCloud Video Export Routine:**

- Add `export_pointcloud_video` routine in `ros2_unbag/core/routines/pointcloud_video.py` to export sequences of PointCloud2 messages as colorized MP4 or AVI videos, with extensive customization options for rendering.
- Especially for this routine, a Preview dialog is implemented to interactively optimize the camera parameters. For performance reasons, this dialog can optionally use a randomly sampled PointCloud

**Routine Argument Handling and Introspection:**

* Enhanced the `ExportRoutine` decorator in `ros2_unbag/core/routines/base.py` to support passing and merging user-supplied `routine_args` with each export call, enabling per-topic routine customization [[1]](diffhunk://#diff-f883d052293a4a734d1eab67656d7d1d1d7969180f38b9ba094e3034f3e9f45aR151) [[2]](diffhunk://#diff-f883d052293a4a734d1eab67656d7d1d1d7969180f38b9ba094e3034f3e9f45aL658-R660) [[3]](diffhunk://#diff-9ef35f79cc9bfa2c5b1e7260c0d804d6949bfb62d075f5b1bdf2cdc3eccc02eaL77-R86).
* Added `ExportRoutine.get_args()` method to introspect extra keyword arguments (beyond the required four) and extract their documentation from routine docstrings, facilitating UI/API discovery of configurable parameters.

**Dependency and Documentation Updates:**

* Added `matplotlib` as a required dependency in `pyproject.toml` to support point cloud rendering.
* Updated `LICENSE-3rdparty` to document the inclusion of `matplotlib`
