### PR TITLE
ReadMe improvements

### DIFF
--- a/.github/scripts/update_apt_badges.py
+++ b/.github/scripts/update_apt_badges.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import gzip
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from urllib.error import URLError
@@ -23,6 +24,26 @@ DISTROS = {
     "rolling": "noble",
 }
 OUTPUT_DIRECTORY = Path(os.environ.get("APT_BADGE_OUTPUT_DIRECTORY", ".github/badges/apt-versions"))
+
+
+def repository_version() -> str | None:
+    """Return the newest semantic version represented by a repository tag."""
+    try:
+        result = subprocess.run(
+            ["git", "tag", "--sort=-version:refname"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        print(f"Could not read repository tags: {error}", file=sys.stderr)
+        return None
+
+    for tag in result.stdout.splitlines():
+        version = tag.removeprefix("v")
+        if tag.startswith("v") and version and all(part.isdigit() for part in version.split(".")):
+            return version
+    return None
 
 
 def package_version(distro: str, ubuntu_codename: str) -> str | None:
@@ -54,13 +75,21 @@ def display_version(apt_version: str | None) -> str | None:
         return None
     return apt_version.rsplit(":", 1)[-1].split("-", 1)[0]
 
-def write_badge(distro: str, version: str | None) -> None:
+
+def badge_color(apt_version: str | None, tag_version: str | None) -> str:
+    """Select green for matching releases, orange for a version mismatch, red if absent."""
+    if apt_version is None:
+        return "e05d44"
+    return "0a7d2c" if display_version(apt_version) == tag_version else "orange"
+
+
+def write_badge(distro: str, version: str | None, tag_version: str | None) -> None:
     """Write an endpoint schema understood by shields.io."""
     badge = {
         "schemaVersion": 1,
         "label": f"apt · ROS 2 {distro.title()}",
         "message": display_version(version) or "unavailable",
-        "color": "0a7d2c" if version else "e05d44",
+        "color": badge_color(version, tag_version),
         "cacheSeconds": 3600,
     }
     destination = OUTPUT_DIRECTORY / f"{distro}.json"
@@ -69,10 +98,12 @@ def write_badge(distro: str, version: str | None) -> None:
 
 
 def main() -> None:
+    tag_version = repository_version()
+    print(f"repository tag: {tag_version or 'unavailable'}")
     for distro, ubuntu_codename in DISTROS.items():
         version = package_version(distro, ubuntu_codename)
         print(f"{distro}: {version or 'unavailable'}")
-        write_badge(distro, version)
+        write_badge(distro, version, tag_version)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/update_apt_badges.py
+++ b/.github/scripts/update_apt_badges.py
@@ -80,14 +80,14 @@ def badge_color(apt_version: str | None, tag_version: str | None) -> str:
     """Select green for matching releases, orange for a version mismatch, red if absent."""
     if apt_version is None:
         return "e05d44"
-    return "0a7d2c" if display_version(apt_version) == tag_version else "orange"
+    return "97ca00" if display_version(apt_version) == tag_version else "orange"
 
 
 def write_badge(distro: str, version: str | None, tag_version: str | None) -> None:
     """Write an endpoint schema understood by shields.io."""
     badge = {
         "schemaVersion": 1,
-        "label": f"apt · ROS 2 {distro.title()}",
+        "label": f"apt · {distro.title()}",
         "message": display_version(version) or "unavailable",
         "color": badge_color(version, tag_version),
         "cacheSeconds": 3600,

--- a/.github/scripts/update_apt_badges.py
+++ b/.github/scripts/update_apt_badges.py
@@ -88,6 +88,8 @@ def write_badge(distro: str, version: str | None, tag_version: str | None) -> No
     badge = {
         "schemaVersion": 1,
         "label": f"apt · {distro.title()}",
+        "namedLogo": "ros",
+        "logoColor": "white",
         "message": display_version(version) or "unavailable",
         "color": badge_color(version, tag_version),
         "cacheSeconds": 3600,

--- a/.github/scripts/update_apt_badges.py
+++ b/.github/scripts/update_apt_badges.py
@@ -87,7 +87,7 @@ def write_badge(distro: str, version: str | None, tag_version: str | None) -> No
     """Write an endpoint schema understood by shields.io."""
     badge = {
         "schemaVersion": 1,
-        "label": f"apt · {distro.title()}",
+        "label": f"{distro.title()}",
         "namedLogo": "ros",
         "logoColor": "white",
         "message": display_version(version) or "unavailable",

--- a/.github/scripts/update_apt_badges.py
+++ b/.github/scripts/update_apt_badges.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Create Shields.io endpoint JSON files for ROS apt package availability."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+
+PACKAGE = "unbag"
+REPOSITORY = os.environ.get("ROS_APT_REPOSITORY", "http://packages.ros.org/ros2/ubuntu")
+DISTROS = {
+    "humble": "jammy",
+    "jazzy": "noble",
+    "kilted": "noble",
+    "lyrical": "noble",
+    # Update this codename when the ROS Rolling apt repository moves to a new Ubuntu release.
+    "rolling": "noble",
+}
+OUTPUT_DIRECTORY = Path(os.environ.get("APT_BADGE_OUTPUT_DIRECTORY", ".github/badges/apt-versions"))
+
+
+def package_version(distro: str, ubuntu_codename: str) -> str | None:
+    """Return the current amd64 apt version for a ROS distribution, if present."""
+    url = f"{REPOSITORY}/dists/{ubuntu_codename}/main/binary-amd64/Packages.gz"
+    target_package = f"ros-{distro}-{PACKAGE}"
+
+    try:
+        with urlopen(url, timeout=30) as response:  # nosec B310: configured ROS apt index endpoint
+            contents = gzip.decompress(response.read()).decode("utf-8")
+    except (OSError, URLError) as error:
+        print(f"Could not query {url}: {error}", file=sys.stderr)
+        return None
+
+    for stanza in contents.split("\n\n"):
+        fields = dict(
+            line.split(": ", 1)
+            for line in stanza.splitlines()
+            if ": " in line and not line.startswith((" ", "\t"))
+        )
+        if fields.get("Package") == target_package:
+            return fields.get("Version")
+    return None
+
+
+def display_version(apt_version: str | None) -> str | None:
+    """Remove an optional Debian epoch and packaging revision from an apt version."""
+    if apt_version is None:
+        return None
+    return apt_version.rsplit(":", 1)[-1].split("-", 1)[0]
+
+def write_badge(distro: str, version: str | None) -> None:
+    """Write an endpoint schema understood by shields.io."""
+    badge = {
+        "schemaVersion": 1,
+        "label": f"apt · ROS 2 {distro.title()}",
+        "message": display_version(version) or "unavailable",
+        "color": "0a7d2c" if version else "e05d44",
+        "cacheSeconds": 3600,
+    }
+    destination = OUTPUT_DIRECTORY / f"{distro}.json"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(badge, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    for distro, ubuntu_codename in DISTROS.items():
+        version = package_version(distro, ubuntu_codename)
+        print(f"{distro}: {version or 'unavailable'}")
+        write_badge(distro, version)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-apt-badges.yml
+++ b/.github/workflows/update-apt-badges.yml
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   update-badges:
     # Badge data is consumed from the default branch, never from feature branches.
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/update-apt-badges.yml
+++ b/.github/workflows/update-apt-badges.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   update-badges:
     # Badge data is consumed from the default branch, never from feature branches.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/update-apt-badges.yml
+++ b/.github/workflows/update-apt-badges.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Query ROS apt repositories
         run: APT_BADGE_OUTPUT_DIRECTORY=_site/apt-versions python3 .github/scripts/update_apt_badges.py
@@ -33,4 +35,4 @@ jobs:
 
       - name: Deploy badge site
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/update-apt-badges.yml
+++ b/.github/workflows/update-apt-badges.yml
@@ -17,8 +17,10 @@ concurrency:
 
 jobs:
   update-badges:
-    # Badge data is consumed from the default branch, never from feature branches.
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    # Automatic runs only deploy from the default branch; manual runs may use any branch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/update-apt-badges.yml
+++ b/.github/workflows/update-apt-badges.yml
@@ -1,0 +1,37 @@
+name: Update apt version badges
+
+on:
+  push:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  update-badges:
+    # Badge data is consumed from the default branch, never from feature branches.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Query ROS apt repositories
+        run: APT_BADGE_OUTPUT_DIRECTORY=_site/apt-versions python3 .github/scripts/update_apt_badges.py
+
+      - name: Upload badge site
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: _site
+
+      - name: Deploy badge site
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ CMakeFiles/
 data/
 !/.github/*.yaml
 !/.github/*.yml
+!/.github/workflows/*.yml

--- a/README.md
+++ b/README.md
@@ -6,9 +6,25 @@
   <img src="https://img.shields.io/github/license/ika-rwth-aachen/ros2_unbag"/>
   <a href="https://github.com/ika-rwth-aachen/ros2_unbag/releases/latest"><img src="https://img.shields.io/github/v/release/ika-rwth-aachen/ros2_unbag"/></a>
   <a href="https://github.com/ika-rwth-aachen/ros2_unbag/actions/workflows/docker-ros.yml"><img src="https://github.com/ika-rwth-aachen/ros2_unbag/actions/workflows/docker-ros.yml/badge.svg"/></a>
+  <br/>
+  <a href="https://repo.ros2.org/status_page/ros_humble_default.html?q=unbag"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fika-rwth-aachen.github.io%2Fros2_unbag%2Fapt-versions%2Fhumble.json" alt="apt package version for ROS 2 Humble"/></a>
+  <a href="https://repo.ros2.org/status_page/ros_jazzy_default.html?q=unbag"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fika-rwth-aachen.github.io%2Fros2_unbag%2Fapt-versions%2Fjazzy.json" alt="apt package version for ROS 2 Jazzy"/></a>
+  <a href="https://repo.ros2.org/status_page/ros_kilted_default.html?q=unbag"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fika-rwth-aachen.github.io%2Fros2_unbag%2Fapt-versions%2Fkilted.json" alt="apt package version for ROS 2 Kilted"/></a>
+  <a href="https://repo.ros2.org/status_page/ros_lyrical_default.html?q=unbag"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fika-rwth-aachen.github.io%2Fros2_unbag%2Fapt-versions%2Flyrical.json" alt="apt package version for ROS 2 Lyrical"/></a>
+  <a href="https://repo.ros2.org/status_page/ros_rolling_default.html?q=unbag"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fika-rwth-aachen.github.io%2Fros2_unbag%2Fapt-versions%2Frolling.json" alt="apt package version for ROS 2 Rolling"/></a>
 </p>
 
 *ros2 unbag* is a powerful ROS 2 tool featuring an **intuitive GUI** and **flexible CLI** for extracting topics from `.db3` or `.mcap` bag files into formats like CSV, JSON, PCD, images, and more.
+
+> [!IMPORTANT]
+> **Official releases are now available as ROS binary packages via `apt`.** PyPI/pip is no longer the official distribution channel.
+>
+> ```bash
+> sudo apt update
+> sudo apt install ros-<distro>-unbag
+> ```
+>
+> Replace `<distro>` with your ROS 2 distribution, such as `humble`, `jazzy`, `lyrical`, or `rolling`.
 
 - **🎨 Intuitive GUI interface** for interactive bag exploration and export configuration
 - **⚙️ Full-featured ROS 2 CLI plugin**: `ros2 unbag <args>` for automation and scripting  
@@ -21,7 +37,7 @@
 ## Table of Contents
 - [Introduction](#introduction)
 - [Installation](#installation)  
-  - [apt (Recommended)](#apt-recommended)  
+  - [Install via apt (Recommended)](#install-via-apt-recommended)
   - [From Source](#from-source)  
   - [Docker](#docker)  
 - [Quick Start](#quick-start)  
@@ -52,16 +68,16 @@ Whether you prefer the **GUI for interactive exploration** or `ros2 unbag <args>
 
 ## Installation 
 
-### apt (Recommended)
+### Install via apt (Recommended)
 
-*ros2 unbag* is released as a binary package for ROS 2 Humble, Jazzy, Lyrical, and Rolling. Install it directly via `apt`:
+*ros2 unbag* is officially released as a binary package for ROS 2 Humble, Jazzy, Lyrical, and Rolling. Install it from the ROS apt repositories:
 
 ```bash
 sudo apt update
 sudo apt install ros-<distro>-unbag
 ```
 
-Replace `<distro>` with your ROS 2 distribution (e.g. `humble`, `jazzy`, `lyrical`, `rolling`). No need to clone or build anything—`ros2 unbag` is available right away after sourcing your ROS 2 installation.
+Replace `<distro>` with your ROS 2 distribution (e.g. `humble`, `jazzy`, `kilted`, `lyrical`, `rolling`). No need to clone or build anything—`ros2 unbag` is available right away after sourcing your ROS 2 installation.
 
 ### From source
 


### PR DESCRIPTION
This pull request introduces automated generation and deployment of Shields.io badges displaying the current ROS apt package versions for *ros2 unbag* across supported distributions. It adds a GitHub Actions workflow and supporting Python script to query the ROS apt repositories, generate badge metadata, and publish the results for use in the project’s README. The documentation is updated to highlight the new badges, clarify installation instructions, and emphasize apt as the recommended installation method.